### PR TITLE
Configurable build options and throw errors if dependencies are missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 
 before_install:
   - "if [ $TRAVIS_OS_NAME == 'osx' ]; then brew update; else true; fi"
-  - "if [ $TRAVIS_OS_NAME == 'osx' ]; then brew install libsodium valgrind swig lua; else true; fi"
+  - "if [ $TRAVIS_OS_NAME == 'osx' ]; then brew install libsodium valgrind swig lua graphviz doxygen; else true; fi"
 script:
   - "git submodule update --init --recursive"
   - "if [ $TRAVIS_OS_NAME == 'linux' ]; then curl -s https://raw.githubusercontent.com/mikkeloscar/arch-travis/master/arch-travis.sh | bash; else true; fi"
@@ -28,5 +28,7 @@ arch:
     - valgrind
     - swig
     - lua
+    - doxygen
+    - graphviz
   script:
       - "bash run-ci.sh"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,14 @@ option(GENERATE_DOC "Generate documentation with Doxygen." OFF)
 
 if (GENERATE_DOC)
     find_package(Doxygen)
-    if (DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND)
-        execute_process(COMMAND ${DOXYGEN_EXECUTABLE}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    if (NOT DOXYGEN_FOUND)
+        message(FATAL_ERROR "Doxygen wasn't found.")
     endif()
+
+    if (NOT DOXYGEN_DOT_FOUND)
+        message(FATAL_ERROR "Graphviz' 'dot' wasn't found.")
+    endif()
+
+    execute_process(COMMAND ${DOXYGEN_EXECUTABLE}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()

--- a/Doxyfile
+++ b/Doxyfile
@@ -734,7 +734,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = address-sanitizer build static-analysis undefined-behavior-sanitizer dummy tracing axolotl-specification/junk.md buffer/address-sanitizer buffer/build buffer/static-analysis buffer/undefined-behavior-sanitizer mcJSON/address-sanitizer mcJSON/build mcJSON/static-analysis mcJSON/undefined-behavior-sanitizer mcJSON/buffer/address-sanitizer mcJSON/buffer/build mcJSON/buffer/static-analysis mcJSON/buffer/undefined-behavior-sanitizer mcJSON/fuzzing
+EXCLUDE                = address-sanitizer build static-analysis undefined-behavior-sanitizer dummy tracing axolotl-specification/junk.md buffer/address-sanitizer buffer/build buffer/static-analysis buffer/undefined-behavior-sanitizer mcJSON/address-sanitizer mcJSON/build mcJSON/static-analysis mcJSON/undefined-behavior-sanitizer mcJSON/buffer/address-sanitizer mcJSON/buffer/build mcJSON/buffer/static-analysis mcJSON/buffer/undefined-behavior-sanitizer mcJSON/fuzzing root.x86_64
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(GENERATE_LUA_BINDINGS "Enable the Lua binding for testing purposes" ON)
+option(GENERATE_LUA_BINDINGS "Enable the Lua binding for testing purposes" OFF)
 
 if(GENERATE_LUA_BINDINGS AND (NOT APPLE))
     find_package(SWIG)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -2,28 +2,31 @@ option(GENERATE_LUA_BINDINGS "Enable the Lua binding for testing purposes" OFF)
 
 if(GENERATE_LUA_BINDINGS AND (NOT APPLE))
     find_package(SWIG)
-    if(SWIG_FOUND)
-        include(${SWIG_USE_FILE})
-        find_package(Lua)
-        if (LUA_FOUND)
-            include_directories(${LUA_INCLUDE_DIR})
-            include_directories(${CMAKE_SOURCE_DIR})
-
-            find_program(LUA_INTERPRETER NAMES lua lua53 lua5.3 lua52 lua5.2 lua51 lua5.1 luajit)
-
-            swig_add_module(molch-interface lua molch.i)
-            swig_link_libraries(molch-interface molch ${LUA_LIBRARIES})
-
-            # copy the lua binding
-            execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/molch.lua" "${CMAKE_CURRENT_BINARY_DIR}/molch.lua")
-
-            find_program(MKFIFO mkfifo)
-            if (NOT (MKFIFO MATCHES "MKFIFO-NOTFOUND"))
-                execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/base64.lua" "${CMAKE_CURRENT_BINARY_DIR}/base64.lua")
-                execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/pipe.lua" "${CMAKE_CURRENT_BINARY_DIR}/pipe.lua")
-            endif()
-
-            subdirs(scenarios)
-        endif()
+    if (NOT SWIG_FOUND)
+        message(FATAL_ERROR "Swig is not installed.")
     endif()
+    include(${SWIG_USE_FILE})
+
+    find_package(Lua)
+    if (NOT LUA_FOUND)
+        message(FATAL_ERROR "Lua is not installed.")
+    endif()
+    include_directories(${LUA_INCLUDE_DIR})
+    include_directories(${CMAKE_SOURCE_DIR})
+
+    find_program(LUA_INTERPRETER NAMES lua lua53 lua5.3 lua52 lua5.2 lua51 lua5.1 luajit)
+
+    swig_add_module(molch-interface lua molch.i)
+    swig_link_libraries(molch-interface molch ${LUA_LIBRARIES})
+
+    # copy the lua binding
+    execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/molch.lua" "${CMAKE_CURRENT_BINARY_DIR}/molch.lua")
+
+    find_program(MKFIFO mkfifo)
+    if (NOT (MKFIFO MATCHES "MKFIFO-NOTFOUND"))
+        execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/base64.lua" "${CMAKE_CURRENT_BINARY_DIR}/base64.lua")
+        execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/pipe.lua" "${CMAKE_CURRENT_BINARY_DIR}/pipe.lua")
+    endif()
+
+    subdirs(scenarios)
 endif()

--- a/ci/address-sanitizer.sh
+++ b/ci/address-sanitizer.sh
@@ -11,7 +11,7 @@ fi
 rm test.c
 
 export CC=clang
-if cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-fsanitize=address -O1 -fno-omit-frame-pointer -fno-common -fno-optimize-sibling-calls -g' -DDISABLE_MEMORYCHECK_COMMAND="TRUE"; then
+if cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Debug -DRUN_TESTS=ON -DCMAKE_C_FLAGS='-fsanitize=address -O1 -fno-omit-frame-pointer -fno-common -fno-optimize-sibling-calls -g' -DDISABLE_MEMORYCHECK_COMMAND="TRUE"; then
     # This has to be done with else because with '!' it won't work on Mac OS X
     echo
 else

--- a/ci/address-sanitizer.sh
+++ b/ci/address-sanitizer.sh
@@ -11,7 +11,7 @@ fi
 rm test.c
 
 export CC=clang
-if cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-fsanitize=address -O1 -fno-omit-frame-pointer -fno-common -fno-optimize-sibling-calls -g' -DDISABLE_MEMORYCHECK_COMMAND="TRUE" -DGENERATE_LUA_BINDINGS=OFF; then
+if cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-fsanitize=address -O1 -fno-omit-frame-pointer -fno-common -fno-optimize-sibling-calls -g' -DDISABLE_MEMORYCHECK_COMMAND="TRUE"; then
     # This has to be done with else because with '!' it won't work on Mac OS X
     echo
 else

--- a/ci/clang-static-analysis.sh
+++ b/ci/clang-static-analysis.sh
@@ -5,7 +5,7 @@ if ! hash scan-build; then
 fi
 [ ! -e static-analysis ] && mkdir static-analysis
 cd static-analysis
-if scan-build --status-bugs cmake ..; then
+if scan-build --status-bugs cmake .. -DRUN_TESTS=ON; then
     # This has to be done with else because with '!' it won't work on Mac OS X
     echo
 else

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,7 +2,7 @@
 [ ! -e build ] && mkdir build
 RETURN_VALUE=0
 cd build
-if cmake .. -DGENERATE_LUA_BINDINGS=ON; then
+if cmake .. -DGENERATE_LUA_BINDINGS=ON -DRUN_TESTS=ON; then
     # This has to be done with else because with '!' it won't work on Mac OS X
     echo
 else

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,7 +2,7 @@
 [ ! -e build ] && mkdir build
 RETURN_VALUE=0
 cd build
-if cmake ..; then
+if cmake .. -DGENERATE_LUA_BINDINGS=ON; then
     # This has to be done with else because with '!' it won't work on Mac OS X
     echo
 else

--- a/ci/undefined-behavior-sanitizer.sh
+++ b/ci/undefined-behavior-sanitizer.sh
@@ -11,7 +11,7 @@ fi
 rm test.c
 
 export CC=clang
-if cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-fsanitize=undefined,integer -fno-sanitize-recover=undefined,integer -O1 -fno-omit-frame-pointer -fno-common -fno-optimize-sibling-calls -g' -DDISABLE_MEMORYCHECK_COMMAND="TRUE"; then
+if cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Debug -DRUN_TESTS=ON -DCMAKE_C_FLAGS='-fsanitize=undefined,integer -fno-sanitize-recover=undefined,integer -O1 -fno-omit-frame-pointer -fno-common -fno-optimize-sibling-calls -g' -DDISABLE_MEMORYCHECK_COMMAND="TRUE"; then
     # This has to be done with else because with '!' it won't work on Mac OS X
     echo
 else

--- a/ci/undefined-behavior-sanitizer.sh
+++ b/ci/undefined-behavior-sanitizer.sh
@@ -11,7 +11,7 @@ fi
 rm test.c
 
 export CC=clang
-if cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-fsanitize=undefined,integer -fno-sanitize-recover=undefined,integer -O1 -fno-omit-frame-pointer -fno-common -fno-optimize-sibling-calls -g' -DDISABLE_MEMORYCHECK_COMMAND="TRUE" -DGENERATE_LUA_BINDINGS=OFF; then
+if cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-fsanitize=undefined,integer -fno-sanitize-recover=undefined,integer -O1 -fno-omit-frame-pointer -fno-common -fno-optimize-sibling-calls -g' -DDISABLE_MEMORYCHECK_COMMAND="TRUE"; then
     # This has to be done with else because with '!' it won't work on Mac OS X
     echo
 else

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,52 +1,56 @@
 cmake_minimum_required (VERSION 2.6)
 
-add_subdirectory(test-data)
+option(RUN_TESTS "Generate the tests." OFF)
 
-add_library(utils utils)
-target_link_libraries(utils molch-buffer)
-if (TRACING)
-    target_link_libraries(utils tracing)
+if (RUN_TESTS)
+    add_subdirectory(test-data)
+
+    add_library(utils utils)
+    target_link_libraries(utils molch-buffer)
+    if (TRACING)
+        target_link_libraries(utils tracing)
+    endif()
+
+    add_library(common common)
+    target_link_libraries(common utils)
+
+    add_library(packet-test-lib packet-test-lib)
+    target_link_libraries(packet-test-lib molch molch-buffer utils)
+
+    set(tests diffie-hellman-test
+              triple-diffie-hellman-test
+              key-derivation-test
+              chain-key-derivation-test
+              message-key-derivation-test
+              root-next-header-and-chain-key-derivation-test
+              initial-root-chain-and-header-key-derivation-test
+              packet-get-metadata-test
+              packet-decrypt-header-test
+              packet-decrypt-message-test
+              packet-decrypt-test
+              header-test
+              header-and-message-keystore-test
+              ratchet-test
+              ratchet-test-simple
+              user-store-test
+              spiced-random-test
+              molch-test
+              conversation-test
+              conversation-packet-test
+              conversation-store-test
+              prekey-store-test
+              master-keys-test
+              endianness-test
+              return-status-test
+              molch-init-test
+    )
+
+    foreach(test ${tests})
+        add_executable(${test} ${test})
+        target_link_libraries(${test} molch molch-buffer utils common packet-test-lib)
+        add_test(${test} "./${test}")
+        if(NOT ("${MEMORYCHECK_COMMAND}" MATCHES "MEMORYCHECK_COMMAND-NOTFOUND"))
+            add_test("${test}-valgrind" ${MEMORYCHECK_COMMAND} ${MEMORYCHECK_COMMAND_OPTIONS} "./${test}")
+        endif(NOT ("${MEMORYCHECK_COMMAND}" MATCHES "MEMORYCHECK_COMMAND-NOTFOUND"))
+    endforeach(test)
 endif()
-
-add_library(common common)
-target_link_libraries(common utils)
-
-add_library(packet-test-lib packet-test-lib)
-target_link_libraries(packet-test-lib molch molch-buffer utils)
-
-set(tests diffie-hellman-test
-          triple-diffie-hellman-test
-          key-derivation-test
-          chain-key-derivation-test
-          message-key-derivation-test
-          root-next-header-and-chain-key-derivation-test
-          initial-root-chain-and-header-key-derivation-test
-          packet-get-metadata-test
-          packet-decrypt-header-test
-          packet-decrypt-message-test
-          packet-decrypt-test
-          header-test
-          header-and-message-keystore-test
-          ratchet-test
-          ratchet-test-simple
-          user-store-test
-          spiced-random-test
-          molch-test
-          conversation-test
-          conversation-packet-test
-          conversation-store-test
-          prekey-store-test
-          master-keys-test
-          endianness-test
-          return-status-test
-          molch-init-test
-)
-
-foreach(test ${tests})
-    add_executable(${test} ${test})
-    target_link_libraries(${test} molch molch-buffer utils common packet-test-lib)
-    add_test(${test} "./${test}")
-    if(NOT ("${MEMORYCHECK_COMMAND}" MATCHES "MEMORYCHECK_COMMAND-NOTFOUND"))
-        add_test("${test}-valgrind" ${MEMORYCHECK_COMMAND} ${MEMORYCHECK_COMMAND_OPTIONS} "./${test}")
-    endif(NOT ("${MEMORYCHECK_COMMAND}" MATCHES "MEMORYCHECK_COMMAND-NOTFOUND"))
-endforeach(test)


### PR DESCRIPTION
This pull request disables Tests and Lua bindings by default and throws an error if the necessary dependencies aren't available.