### PR TITLE
CMake enhancements

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -19,14 +19,35 @@ if(GENERATE_LUA_BINDINGS AND (NOT APPLE))
     swig_add_module(molch-interface lua molch.i)
     swig_link_libraries(molch-interface molch ${LUA_LIBRARIES})
 
+    set(BINDING_FILES "${CMAKE_CURRENT_BINARY_DIR}/molch.lua")
+
     # copy the lua binding
-    execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/molch.lua" "${CMAKE_CURRENT_BINARY_DIR}/molch.lua")
+    add_custom_command(
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/molch.lua"
+        COMMAND "${CMAKE_COMMAND}"
+        ARGS -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/molch.lua" "${CMAKE_CURRENT_BINARY_DIR}/molch.lua"
+        COMMENT "Copying molch.lua"
+        VERBATIM)
 
     find_program(MKFIFO mkfifo)
     if (NOT (MKFIFO MATCHES "MKFIFO-NOTFOUND"))
-        execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/base64.lua" "${CMAKE_CURRENT_BINARY_DIR}/base64.lua")
-        execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/pipe.lua" "${CMAKE_CURRENT_BINARY_DIR}/pipe.lua")
+        add_custom_command(
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/base64.lua"
+            COMMAND "${CMAKE_COMMAND}"
+            ARGS -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/base64.lua" "${CMAKE_CURRENT_BINARY_DIR}/base64.lua"
+            COMMENT "Copying base64.lua"
+            VERBATIM)
+        add_custom_command(
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/pipe.lua"
+            COMMAND "${CMAKE_COMMAND}"
+            ARGS -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/pipe.lua" "${CMAKE_CURRENT_BINARY_DIR}/pipe.lua"
+            COMMENT "Copying pipe.lua"
+            VERBATIM)
+
+        list(APPEND BINDING_FILES "${CMAKE_CURRENT_BINARY_DIR}/base64.lua" "${CMAKE_CURRENT_BINARY_DIR}/pipe.lua")
     endif()
+
+    add_custom_target(lua-bindings ALL SOURCES ${BINDING_FILES})
 
     subdirs(scenarios)
 endif()

--- a/bindings/scenarios/CMakeLists.txt
+++ b/bindings/scenarios/CMakeLists.txt
@@ -1,19 +1,33 @@
-set(scenarios normal-conversation reordering invalid_message double-import restart)
+set(scenarios normal-conversation reordering invalid_message double-import restart fail)
 
-execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/scenarios.lua" "${CMAKE_CURRENT_BINARY_DIR}/scenarios.lua")
+add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scenarios.lua"
+    COMMAND ${CMAKE_COMMAND}
+    ARGS -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/scenarios.lua" "${CMAKE_CURRENT_BINARY_DIR}/scenarios.lua"
+    COMMENT "Copying scenarios.lua"
+    VERBATIM)
+set(SCENARIO_FILES "${CMAKE_CURRENT_BINARY_DIR}/scenarios.lua")
 
 # copy all scenarios to the test binary dir
 foreach(scenario ${scenarios})
-    execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/${scenario}" "${CMAKE_CURRENT_BINARY_DIR}/${scenario}")
-    if(NOT ("${LUA_INTERPRETER}" MATCHES "LUA_INTERPRETER-NOTFOUND"))
+    add_custom_command(
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${scenario}"
+        COMMAND "${CMAKE_COMMAND}"
+        ARGS -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/${scenario}" "${CMAKE_CURRENT_BINARY_DIR}/${scenario}"
+        COMMENT "Copying scenario ${scenario}"
+        VERBATIM
+    )
+    list(APPEND SCENARIO_FILES "${CMAKE_CURRENT_BINARY_DIR}/${scenario}")
+    if((NOT ("${LUA_INTERPRETER}" MATCHES "LUA_INTERPRETER-NOTFOUND")) AND (NOT ("${scenario}" MATCHES "fail")))
         add_test("scenario-${scenario}" sh -c "cat scenarios.lua ${CMAKE_CURRENT_BINARY_DIR}/${scenario} | ${LUA_INTERPRETER}")
         set_property(TEST "scenario-${scenario}" PROPERTY FAIL_REGULAR_EXPRESSION "^${LUA_INTERPRETER}: ")
     endif()
 endforeach()
 
 # negative test
-execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/fail" "${CMAKE_CURRENT_BINARY_DIR}/fail")
 if (NOT ("${LUA_INTERPRETER}" MATCHES "LUA_INTERPRETER-NOTFOUND"))
     add_test("scenario-fail" sh -c "cat scenarios.lua ${CMAKE_CURRENT_BINARY_DIR}/fail | ${LUA_INTERPRETER}")
     set_property(TEST "scenario-fail" PROPERTY WILL_FAIL TRUE)
 endif()
+
+add_custom_target(lua-scenarios ALL SOURCES ${SCENARIO_FILES})

--- a/bindings/scenarios/CMakeLists.txt
+++ b/bindings/scenarios/CMakeLists.txt
@@ -19,14 +19,14 @@ foreach(scenario ${scenarios})
     )
     list(APPEND SCENARIO_FILES "${CMAKE_CURRENT_BINARY_DIR}/${scenario}")
     if((NOT ("${LUA_INTERPRETER}" MATCHES "LUA_INTERPRETER-NOTFOUND")) AND (NOT ("${scenario}" MATCHES "fail")))
-        add_test("scenario-${scenario}" sh -c "cat scenarios.lua ${CMAKE_CURRENT_BINARY_DIR}/${scenario} | ${LUA_INTERPRETER}")
+        add_test("scenario-${scenario}" "${LUA_INTERPRETER}" "${CMAKE_CURRENT_BINARY_DIR}/scenarios.lua" "${CMAKE_CURRENT_BINARY_DIR}/${scenario}")
         set_property(TEST "scenario-${scenario}" PROPERTY FAIL_REGULAR_EXPRESSION "^${LUA_INTERPRETER}: ")
     endif()
 endforeach()
 
 # negative test
 if (NOT ("${LUA_INTERPRETER}" MATCHES "LUA_INTERPRETER-NOTFOUND"))
-    add_test("scenario-fail" sh -c "cat scenarios.lua ${CMAKE_CURRENT_BINARY_DIR}/fail | ${LUA_INTERPRETER}")
+    add_test("scenario-fail" "${LUA_INTERPRETER}" "${CMAKE_CURRENT_BINARY_DIR}/scenarios.lua" "${CMAKE_CURRENT_BINARY_DIR}/fail")
     set_property(TEST "scenario-fail" PROPERTY WILL_FAIL TRUE)
 endif()
 

--- a/bindings/scenarios/scenarios.lua
+++ b/bindings/scenarios/scenarios.lua
@@ -1,3 +1,4 @@
+#!/usr/bin/env lua
 -- Molch, an implementation of the axolotl ratchet based on libsodium
 --
 -- ISC License
@@ -27,8 +28,8 @@ local alice = molch.user.new()
 local bob = molch.user.new()
 
 -- stacks for sent packets
-local alice_sent = {}
-local bob_sent = {}
+alice_sent = {}
+bob_sent = {}
 
 local alice_conversation = nil
 local bob_conversation = nil
@@ -272,3 +273,5 @@ function errors_off()
 		_G[name] = func
 	end
 end
+
+dofile(arg[1])

--- a/test/test-data/CMakeLists.txt
+++ b/test/test-data/CMakeLists.txt
@@ -4,5 +4,13 @@ set(test-files molch-init.backup molch-init-backup.key)
 
 # copy all test files to the test binary dir
 foreach(test-file ${test-files})
-    execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/${test-file}" "${CMAKE_CURRENT_BINARY_DIR}/${test-file}")
+    add_custom_command(
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test-file}"
+        COMMAND ${CMAKE_COMMAND}
+        ARGS -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/${test-file}" "${CMAKE_CURRENT_BINARY_DIR}/${test-file}"
+        COMMENT "Copying ${test-file}"
+        VERBATIM)
+    list(APPEND test-data-sources "${CMAKE_CURRENT_BINARY_DIR}/${test-file}")
 endforeach()
+
+add_custom_target(test-data ALL SOURCES ${test-data-sources})


### PR DESCRIPTION
This enhances the CMake build files by applying knowledge that has been acquired while adding Protobuf-C to  the build process.

Mostly replacing `execute_process` with `add_custom_command`, thereby also fixing problems with files that weren't copied even though they had been changed, therefore being then outdated in the build directory.