### PR TITLE
common: and_null_if_valid + on_error improvements

### DIFF
--- a/lib/common.h
+++ b/lib/common.h
@@ -26,21 +26,36 @@
 
 #include "return-status.h"
 
+// execute code if a pointer is not NULL
+#define if_valid(pointer, code)\
+	if (pointer != NULL) {\
+		code\
+	}
 // macros that free memory and delete the pointer afterwards
-#define free_and_null(pointer)\
-	free(pointer);\
-	pointer = NULL;
-#define sodium_free_and_null(pointer)\
-	sodium_free(pointer);\
-	pointer = NULL;
-#define zeroed_free_and_null(pointer)\
-	zeroed_free(pointer);\
-	pointer = NULL;
-#define buffer_destroy_from_heap_and_null(buffer)\
-	buffer_destroy_from_heap(buffer);\
-	buffer = NULL;
-#define buffer_destroy_with_custom_deallocator_and_null(buffer, deallocator)\
-	buffer_destroy_with_custom_deallocator(buffer, deallocator);\
-	buffer = NULL;
+#define free_and_null_if_valid(pointer)\
+	if_valid(pointer,\
+		free(pointer);\
+		pointer = NULL;\
+	)
+#define sodium_free_and_null_if_valid(pointer)\
+	if_valid(pointer,\
+		sodium_free(pointer);\
+		pointer = NULL;\
+	)
+#define zeroed_free_and_null_if_valid(pointer)\
+	if_valid(pointer,\
+		zeroed_free(pointer);\
+		pointer = NULL;\
+	)
+#define buffer_destroy_from_heap_and_null_if_valid(buffer)\
+	if_valid(buffer,\
+		buffer_destroy_from_heap(buffer);\
+		buffer = NULL;\
+	)
+#define buffer_destroy_with_custom_deallocator_and_null_if_valid(buffer, deallocator)\
+	if_valid(buffer,\
+		buffer_destroy_with_custom_deallocator(buffer, deallocator);\
+		buffer = NULL;\
+	)
 
 #endif

--- a/lib/conversation-store.c
+++ b/lib/conversation-store.c
@@ -134,11 +134,11 @@ return_status conversation_store_find_node(
 	*conversation = NULL;
 
 	conversation_store_foreach(store,
-			if (buffer_compare(value->id, id) == 0) {
-				*conversation = node;
-				break;
-			}
-		);
+		if (buffer_compare(value->id, id) == 0) {
+			*conversation = node;
+			break;
+		}
+	)
 
 cleanup:
 
@@ -189,16 +189,14 @@ return_status conversation_store_list(buffer_t ** const list, conversation_store
 			if (status_int != 0) {
 				throw(BUFFER_ERROR, "Failed to copy conversation id.");
 			}
-	);
+	)
 
 cleanup:
-	if (status.status != SUCCESS) {
+	on_error(
 		if (list != NULL) {
-			if (*list != NULL) {
-				buffer_destroy_from_heap_and_null(*list);
-			}
+				buffer_destroy_from_heap_and_null_if_valid(*list);
 		}
-	}
+	)
 
 	return status;
 }
@@ -226,7 +224,7 @@ mcJSON *conversation_store_json_export(const conversation_store * const store, m
 			return NULL;
 		}
 		mcJSON_AddItemToArray(json, conversation, pool);
-	);
+	)
 
 	return json;
 }
@@ -266,7 +264,7 @@ int conversation_store_json_import(
 	}
 
 cleanup:
-	if (status.status != 0) {
+	on_error(
 		if (node != NULL) {
 			conversation_destroy(node);
 		}
@@ -274,7 +272,7 @@ cleanup:
 		if (store != NULL) {
 			conversation_store_clear(store);
 		}
-	}
+	)
 
 	return_status_destroy_errors(&status);
 

--- a/lib/conversation.c
+++ b/lib/conversation.c
@@ -92,11 +92,11 @@ return_status conversation_create(
 	throw_on_error(CREATION_ERROR, "Failed to create ratchet.");
 
 cleanup:
-	if (status.status != 0) {
-		if ((conversation != NULL) && (*conversation != NULL)) {
-			free_and_null(*conversation);
+	on_error(
+		if (conversation != NULL) {
+			free_and_null_if_valid(*conversation);
 		}
-	}
+	)
 
 	return status;
 }
@@ -190,7 +190,7 @@ cleanup:
 			ratchet_destroy(conversation->ratchet);
 		}
 
-		free_and_null(conversation);
+		free_and_null_if_valid(conversation);
 
 		return NULL;
 	}
@@ -272,17 +272,17 @@ return_status conversation_start_send_conversation(
 	throw_on_error(SEND_ERROR, "Failed to send message using newly created conversation.");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(sender_public_ephemeral);
-	buffer_destroy_from_heap_and_null(sender_private_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(sender_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(sender_private_ephemeral);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		if (conversation != NULL) {
 			if (*conversation != NULL) {
 				conversation_destroy(*conversation);
 			}
 			*conversation = NULL;
 		}
-	}
+	)
 
 	return status;
 }
@@ -376,19 +376,19 @@ return_status conversation_start_receive_conversation(
 	throw_on_error(RECEIVE_ERROR, "Failed to receive message.");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(receiver_public_prekey);
-	buffer_destroy_from_heap_and_null(receiver_private_prekey);
-	buffer_destroy_from_heap_and_null(sender_public_ephemeral);
-	buffer_destroy_from_heap_and_null(sender_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(receiver_public_prekey);
+	buffer_destroy_from_heap_and_null_if_valid(receiver_private_prekey);
+	buffer_destroy_from_heap_and_null_if_valid(sender_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(sender_public_identity);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		if (conversation != NULL) {
 			if (*conversation != NULL) {
 				conversation_destroy(*conversation);
 			}
 			*conversation = NULL;
 		}
-	}
+	)
 
 	return status;
 }
@@ -480,19 +480,15 @@ return_status conversation_send(
 	throw_on_error(ENCRYPT_ERROR, "Failed to encrypt packet.");
 
 cleanup:
-	if (status.status != SUCCESS) {
+	on_error(
 		if (packet != NULL) {
-			if (*packet != NULL) {
-				buffer_destroy_from_heap_and_null(*packet);
-			}
+			buffer_destroy_from_heap_and_null_if_valid(*packet);
 		}
-	}
-	buffer_destroy_from_heap_and_null(send_header_key);
-	buffer_destroy_from_heap_and_null(send_message_key);
-	buffer_destroy_from_heap_and_null(send_ephemeral_key);
-	if (header != NULL) {
-		buffer_destroy_from_heap_and_null(header);
-	}
+	)
+	buffer_destroy_from_heap_and_null_if_valid(send_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(send_message_key);
+	buffer_destroy_from_heap_and_null_if_valid(send_ephemeral_key);
+	buffer_destroy_from_heap_and_null_if_valid(header);
 
 	return status;
 }
@@ -548,15 +544,14 @@ int try_skipped_header_and_message_keys(
 	status.status = NOT_FOUND;
 
 cleanup:
-	if (header != NULL) {
-		buffer_destroy_from_heap_and_null(header);
-	}
+	buffer_destroy_from_heap_and_null_if_valid(header);
+
 	on_error(
-		if ((message != NULL) && (*message != NULL)) {
-			buffer_destroy_from_heap_and_null(*message);
+		if (message != NULL) {
+			buffer_destroy_from_heap_and_null_if_valid(*message);
 		}
-	);
-	buffer_destroy_from_heap_and_null(their_signed_public_ephemeral);
+	)
+	buffer_destroy_from_heap_and_null_if_valid(their_signed_public_ephemeral);
 
 	return_status_destroy_errors(&status);
 
@@ -685,7 +680,7 @@ return_status conversation_receive(
 		authenticity_status = ratchet_set_last_message_authenticity(conversation->ratchet, false);
 		return_status_destroy_errors(&authenticity_status);
 		throw(DECRYPT_ERROR, "Failed to decrypt message.");
-	);
+	)
 
 	status = ratchet_set_last_message_authenticity(conversation->ratchet, true);
 	throw_on_error(DATA_SET_ERROR, "Failed to set message authenticity.");
@@ -701,19 +696,15 @@ cleanup:
 			return_status_destroy_errors(&authenticity_status);
 		}
 		if (message != NULL) {
-			if (*message != NULL) {
-				buffer_destroy_from_heap_and_null(*message);
-			}
+			buffer_destroy_from_heap_and_null_if_valid(*message);
 		}
-	);
+	)
 
-	buffer_destroy_from_heap_and_null(current_receive_header_key);
-	buffer_destroy_from_heap_and_null(next_receive_header_key);
-	if (header != NULL) {
-		buffer_destroy_from_heap_and_null(header);
-	}
-	buffer_destroy_from_heap_and_null(their_signed_public_ephemeral);
-	buffer_destroy_from_heap_and_null(message_key);
+	buffer_destroy_from_heap_and_null_if_valid(current_receive_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(next_receive_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(header);
+	buffer_destroy_from_heap_and_null_if_valid(their_signed_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(message_key);
 
 	return status;
 }

--- a/lib/diffie-hellman.c
+++ b/lib/diffie-hellman.c
@@ -123,7 +123,7 @@ return_status diffie_hellman(
 	derived_key->content_length = DIFFIE_HELLMAN_SIZE;
 
 cleanup:
-	buffer_destroy_from_heap_and_null(dh_secret);
+	buffer_destroy_from_heap_and_null_if_valid(dh_secret);
 	sodium_memzero(hash_state, sizeof(crypto_generichash_state));
 
 	return status;
@@ -274,9 +274,9 @@ return_status triple_diffie_hellman(
 	sodium_memzero(hash_state, sizeof(crypto_generichash_state));
 
 cleanup:
-	buffer_destroy_from_heap_and_null(dh1);
-	buffer_destroy_from_heap_and_null(dh2);
-	buffer_destroy_from_heap_and_null(dh3);
+	buffer_destroy_from_heap_and_null_if_valid(dh1);
+	buffer_destroy_from_heap_and_null_if_valid(dh2);
+	buffer_destroy_from_heap_and_null_if_valid(dh3);
 
 	return status;
 }

--- a/lib/header-and-message-keystore.c
+++ b/lib/header-and-message-keystore.c
@@ -98,12 +98,12 @@ return_status header_and_message_keystore_add(
 	new_node->expiration_date = time(NULL) + EXPIRATION_TIME;
 	status_int = buffer_clone(new_node->message_key, message_key);
 	if (status_int != 0) {
-		sodium_free_and_null(new_node);
+		sodium_free_and_null_if_valid(new_node);
 		throw(BUFFER_ERROR, "Failed to copy message key.");
 	}
 	status_int = buffer_clone(new_node->header_key, header_key);
 	if (status_int != 0) {
-		sodium_free_and_null(new_node);
+		sodium_free_and_null_if_valid(new_node);
 		throw(BUFFER_ERROR, "Failed to copy header key.");
 	}
 
@@ -131,7 +131,7 @@ void header_and_message_keystore_remove(header_and_message_keystore *keystore, h
 	}
 
 	//free node and overwrite with zero
-	sodium_free_and_null(node);
+	sodium_free_and_null_if_valid(node);
 
 	//update length
 	keystore->length--;
@@ -251,7 +251,7 @@ int header_and_message_keystore_json_import(
 		//copy the mesage key
 		int status = buffer_clone_from_hex(node->message_key, message_key->valuestring);
 		if (status != 0) {
-			sodium_free_and_null(node);
+			sodium_free_and_null_if_valid(node);
 			header_and_message_keystore_clear(keystore);
 			return status;
 		}
@@ -259,7 +259,7 @@ int header_and_message_keystore_json_import(
 		//copy the header key
 		status = buffer_clone_from_hex(node->header_key, header_key->valuestring);
 		if (status != 0) {
-			sodium_free_and_null(node);
+			sodium_free_and_null_if_valid(node);
 			header_and_message_keystore_clear(keystore);
 			return status;
 		}

--- a/lib/header.c
+++ b/lib/header.c
@@ -71,9 +71,9 @@ return_status header_construct(
 cleanup:
 	on_error(
 		if ((header != NULL) && (*header != NULL)) {
-			buffer_destroy_from_heap_and_null(*header);
+			buffer_destroy_from_heap_and_null_if_valid(*header);
 		}
-	);
+	)
 	return status;
 }
 

--- a/lib/key-derivation.c
+++ b/lib/key-derivation.c
@@ -87,8 +87,8 @@ cleanup:
 		if (derived_key != NULL) {
 			derived_key->content_length = 0;
 		}
-	);
-	buffer_destroy_from_heap_and_null(salt);
+	)
+	buffer_destroy_from_heap_and_null_if_valid(salt);
 
 	return status;
 }
@@ -228,10 +228,10 @@ cleanup:
 			buffer_clear(chain_key);
 			chain_key->content_length = 0;
 		}
-	);
+	)
 
-	buffer_destroy_from_heap_and_null(diffie_hellman_secret);
-	buffer_destroy_from_heap_and_null(derivation_key);
+	buffer_destroy_from_heap_and_null_if_valid(diffie_hellman_secret);
+	buffer_destroy_from_heap_and_null_if_valid(derivation_key);
 
 	return status;
 }
@@ -404,9 +404,9 @@ cleanup:
 		next_send_header_key->content_length = 0;
 		buffer_clear(next_receive_header_key);
 		next_receive_header_key->content_length = 0;
-	);
+	)
 
-	buffer_destroy_from_heap_and_null(master_key);
+	buffer_destroy_from_heap_and_null_if_valid(master_key);
 
 	return status;
 }

--- a/lib/master-keys.c
+++ b/lib/master-keys.c
@@ -129,19 +129,15 @@ return_status master_keys_create(
 	}
 
 cleanup:
-	if (crypto_seeds != NULL) {
-		buffer_destroy_with_custom_deallocator_and_null(crypto_seeds, sodium_free);
-	}
+	buffer_destroy_with_custom_deallocator_and_null_if_valid(crypto_seeds, sodium_free);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		if (keys != NULL) {
-			if (*keys != NULL) {
-				sodium_free_and_null(*keys);
-			}
+			sodium_free_and_null_if_valid(*keys);
 		}
 
 		return status;
-	}
+	)
 
 	if ((keys != NULL) && (*keys != NULL)) {
 		sodium_mprotect_noaccess(*keys);
@@ -240,11 +236,11 @@ cleanup:
 		sodium_mprotect_noaccess(keys);
 	}
 
-	if (status.status != SUCCESS) {
+	on_error(
 		if (signed_data != NULL) {
 			signed_data->content_length = 0;
 		}
-	}
+	)
 
 	return status;
 }
@@ -370,7 +366,7 @@ master_keys *master_keys_json_import(const mcJSON * const json) {
 	goto cleanup;
 
 fail:
-	sodium_free_and_null(keys);
+	sodium_free_and_null_if_valid(keys);
 
 	return NULL;
 

--- a/lib/molch.h
+++ b/lib/molch.h
@@ -231,8 +231,7 @@ void molch_end_conversation(
 		const size_t conversation_id_length,
 		//optional output (can be NULL)
 		unsigned char ** const backup, //exports the entire library state, free after use, check if NULL before use!
-		size_t * const backup_length
-		);
+		size_t * const backup_length);
 
 /*
  * List the conversations of a user.

--- a/lib/packet.c
+++ b/lib/packet.c
@@ -122,7 +122,7 @@ cleanup:
 			packet__free_unpacked(*packet_struct, &protobuf_c_allocators);
 			*packet_struct = NULL;
 		}
-	);
+	)
 
 	return status;
 }
@@ -281,30 +281,16 @@ return_status packet_encrypt(
 
 cleanup:
 	on_error(
-		if ((packet != NULL) && (*packet != NULL)) {
-			buffer_destroy_from_heap_and_null(*packet);
+		if (packet != NULL) {
+			buffer_destroy_from_heap_and_null_if_valid(*packet);
 		}
-	);
+	)
 
-	if (header_nonce != NULL) {
-		buffer_destroy_from_heap_and_null(header_nonce);
-	}
-
-	if (message_nonce != NULL) {
-		buffer_destroy_from_heap_and_null(message_nonce);
-	}
-
-	if (encrypted_axolotl_header != NULL) {
-		buffer_destroy_from_heap_and_null(encrypted_axolotl_header);
-	}
-
-	if (padded_message != NULL) {
-		buffer_destroy_from_heap_and_null(padded_message);
-	}
-
-	if (encrypted_message != NULL) {
-		buffer_destroy_from_heap_and_null(encrypted_message);
-	}
+	buffer_destroy_from_heap_and_null_if_valid(header_nonce);
+	buffer_destroy_from_heap_and_null_if_valid(message_nonce);
+	buffer_destroy_from_heap_and_null_if_valid(encrypted_axolotl_header);
+	buffer_destroy_from_heap_and_null_if_valid(padded_message);
+	buffer_destroy_from_heap_and_null_if_valid(encrypted_message);
 
 	return status;
 }
@@ -365,14 +351,12 @@ cleanup:
 			*packet_type = INVALID;
 		}
 
-		if ((axolotl_header != NULL) && (*axolotl_header != NULL)) {
-			buffer_destroy_from_heap_and_null(*axolotl_header);
-			*axolotl_header = NULL;
+		if (axolotl_header != NULL) {
+			buffer_destroy_from_heap_and_null_if_valid(*axolotl_header);
 		}
 
-		if ((message != NULL) && (*message != NULL)) {
-			buffer_destroy_from_heap_and_null(*message);
-			*message = NULL;
+		if (message != NULL) {
+			buffer_destroy_from_heap_and_null_if_valid(*message);
 		}
 
 		if (public_identity_key != NULL) {
@@ -386,7 +370,7 @@ cleanup:
 		if (public_prekey != NULL) {
 			buffer_clear(public_prekey);
 		}
-	);
+	)
 
 	return status;
 }
@@ -462,7 +446,7 @@ cleanup:
 		if (packet_type != NULL) {
 			*packet_type = INVALID;
 		}
-	);
+	)
 
 	return status;
 }
@@ -511,14 +495,11 @@ cleanup:
 		packet__free_unpacked(packet_struct, &protobuf_c_allocators);
 	}
 
-	if (axolotl_header != NULL) {
-		on_error(
-			if (*axolotl_header != NULL) {
-				buffer_destroy_from_heap_and_null(*axolotl_header);
-				*axolotl_header = NULL;
-			}
-		);
-	}
+	on_error(
+		if (axolotl_header != NULL) {
+			buffer_destroy_from_heap_and_null_if_valid(*axolotl_header);
+		}
+	)
 
 	return status;
 }
@@ -587,18 +568,13 @@ cleanup:
 		packet__free_unpacked(packet_struct, &protobuf_c_allocators);
 	}
 
-	if (padded_message != NULL) {
-		buffer_destroy_from_heap_and_null(padded_message);
-	}
+	buffer_destroy_from_heap_and_null_if_valid(padded_message);
 
-	if (message != NULL) {
-		on_error(
-			if (*message != NULL) {
-				buffer_destroy_from_heap_and_null(*message);
-				*message = NULL;
-			}
-		);
-	}
+	on_error(
+		if (message != NULL) {
+			buffer_destroy_from_heap_and_null_if_valid(*message);
+		}
+	)
 
 	return status;
 }

--- a/lib/prekey-store.c
+++ b/lib/prekey-store.c
@@ -76,14 +76,11 @@ return_status prekey_store_create(prekey_store ** const store) {
 	}
 
 cleanup:
-	if (status.status != SUCCESS) {
+	on_error(
 		if (store != NULL) {
-			if (*store != NULL) {
-				sodium_free_and_null(*store);
-				*store = NULL;
-			}
+				sodium_free_and_null_if_valid(*store);
 		}
-	}
+	)
 
 	return status;
 }
@@ -140,8 +137,8 @@ int deprecate(prekey_store * const store, size_t index) {
 	store->prekeys[index].expiration_date = time(NULL) + PREKEY_EXPIRATION_TIME;
 
 cleanup:
-	if ((status != 0) && (deprecated_node != NULL)) {
-		sodium_free_and_null(deprecated_node);
+	if (status != 0) {
+		sodium_free_and_null_if_valid(deprecated_node);
 	}
 
 	return status;
@@ -309,7 +306,7 @@ return_status prekey_store_rotate(prekey_store * const store) {
 		while(next != NULL) {
 			if (next->expiration_date < current_time) {
 				*last_pointer = next->next;
-				sodium_free_and_null(next);
+				sodium_free_and_null_if_valid(next);
 				next = *last_pointer;
 				continue;
 			} else if (next->expiration_date < new_oldest_deprecated_expiration_date) {
@@ -333,7 +330,7 @@ void prekey_store_destroy(prekey_store * const store) {
 	while (store->deprecated_prekeys != NULL) {
 		prekey_store_node *node = store->deprecated_prekeys;
 		store->deprecated_prekeys = node->next;
-		sodium_free_and_null(node);
+		sodium_free_and_null_if_valid(node);
 	}
 }
 

--- a/lib/ratchet.c
+++ b/lib/ratchet.c
@@ -180,11 +180,9 @@ return_status ratchet_create(
 cleanup:
 	on_error(
 		if (ratchet != NULL) {
-			if (*ratchet != NULL) {
-				sodium_free_and_null(*ratchet);
-			}
+				sodium_free_and_null_if_valid(*ratchet);
 		}
-	);
+	)
 
 	return status;
 }
@@ -318,10 +316,10 @@ cleanup:
 			buffer_clear(message_key);
 			message_key->content_length = 0;
 		}
-	);
+	)
 
-	buffer_destroy_from_heap_and_null(root_key_backup);
-	buffer_destroy_from_heap_and_null(chain_key_backup);
+	buffer_destroy_from_heap_and_null_if_valid(root_key_backup);
+	buffer_destroy_from_heap_and_null_if_valid(chain_key_backup);
 
 	return status;
 }
@@ -359,7 +357,7 @@ cleanup:
 			buffer_clear(next_receive_header_key);
 			next_receive_header_key->content_length = 0;
 		}
-	);
+	)
 
 	return status;
 }
@@ -486,11 +484,11 @@ cleanup:
 		if (staging_area != NULL) {
 			header_and_message_keystore_clear(staging_area);
 		}
-	);
+	)
 
-	buffer_destroy_from_heap_and_null(current_chain_key);
-	buffer_destroy_from_heap_and_null(next_chain_key);
-	buffer_destroy_from_heap_and_null(current_message_key);
+	buffer_destroy_from_heap_and_null_if_valid(current_chain_key);
+	buffer_destroy_from_heap_and_null_if_valid(next_chain_key);
+	buffer_destroy_from_heap_and_null_if_valid(current_message_key);
 
 	return status;
 }
@@ -650,11 +648,11 @@ cleanup:
 			buffer_clear(message_key);
 			message_key->content_length = 0;
 		}
-	);
+	)
 
-	buffer_destroy_from_heap_and_null(throwaway_chain_key);
-	buffer_destroy_from_heap_and_null(throwaway_message_key);
-	buffer_destroy_from_heap_and_null(purported_chain_key_backup);
+	buffer_destroy_from_heap_and_null_if_valid(throwaway_chain_key);
+	buffer_destroy_from_heap_and_null_if_valid(throwaway_message_key);
+	buffer_destroy_from_heap_and_null_if_valid(purported_chain_key_backup);
 
 	return status;
 }
@@ -735,7 +733,7 @@ void ratchet_destroy(ratchet_state *state) {
 	header_and_message_keystore_clear(state->skipped_header_and_message_keys);
 	header_and_message_keystore_clear(state->staged_header_and_message_keys);
 
-	sodium_free_and_null(state); //this also overwrites all the keys with zeroes
+	sodium_free_and_null_if_valid(state); //this also overwrites all the keys with zeroes
 }
 
 /*
@@ -1171,7 +1169,7 @@ cleanup:
 			ratchet_destroy(state);
 			state = NULL;
 		}
-	);
+	)
 
 	return_status_destroy_errors(&status);
 

--- a/lib/return-status.c
+++ b/lib/return-status.c
@@ -67,7 +67,7 @@ void return_status_destroy_errors(return_status * const status) {
 
 	while (status->error != NULL) {
 		error_message *next_error = status->error->next;
-		free_and_null(status->error);
+		free_and_null_if_valid(status->error);
 		status->error = next_error;
 	}
 }
@@ -329,16 +329,13 @@ cleanup:
 	; // C programming language, I really really love you (not)
 	char *output_string = NULL;
 	if (status.status != SUCCESS) {
-		if (output != NULL) {
-			buffer_destroy_from_heap_and_null(output);
-			output = NULL;
-		}
+		buffer_destroy_from_heap_and_null_if_valid(output);
 	} else {
 		output_string = (char*) output->content;
 		if (length != NULL) {
 			*length = output->content_length;
 		}
-		free_and_null(output);
+		free_and_null_if_valid(output);
 	}
 
 	return_status_destroy_errors(&status);

--- a/lib/spiced-random.c
+++ b/lib/spiced-random.c
@@ -87,14 +87,14 @@ return_status spiced_random(
 	}
 
 cleanup:
-	if (status.status != SUCCESS) {
+	on_error(
 		if (random_output != NULL) {
 			buffer_clear(random_output);
 			random_output->content_length = 0;
 		}
-	}
-	buffer_destroy_with_custom_deallocator_and_null(spice, sodium_free);
-	buffer_destroy_with_custom_deallocator_and_null(os_random, sodium_free);
+	)
+	buffer_destroy_with_custom_deallocator_and_null_if_valid(spice, sodium_free);
+	buffer_destroy_with_custom_deallocator_and_null_if_valid(os_random, sodium_free);
 
 	return status;
 }

--- a/lib/user-store.c
+++ b/lib/user-store.c
@@ -43,11 +43,11 @@ return_status user_store_create(user_store ** const store) {
 	(*store)->tail = NULL;
 
 cleanup:
-	if (status.status != SUCCESS) {
+	on_error(
 		if (store != NULL) {
 			*store = NULL;
 		}
-	}
+	)
 
 	return status;
 }
@@ -56,7 +56,7 @@ cleanup:
 void user_store_destroy(user_store* store) {
 	if (store != NULL) {
 		user_store_clear(store);
-		sodium_free_and_null(store);
+		sodium_free_and_null_if_valid(store);
 	}
 }
 
@@ -111,11 +111,11 @@ return_status create_user_store_node(user_store_node ** const node) {
 	conversation_store_init((*node)->conversations);
 
 cleanup:
-	if (status.status != SUCCESS) {
+	on_error(
 		if (node != NULL) {
 			*node = NULL;
 		}
-	}
+	)
 
 	return status;
 }
@@ -165,18 +165,18 @@ return_status user_store_create_user(
 	add_user_store_node(store, new_node);
 
 cleanup:
-	if (status.status != SUCCESS) {
+	on_error(
 		if (new_node != NULL) {
 			if (new_node->prekeys != NULL) {
 				prekey_store_destroy(new_node->prekeys);
 			}
 			if (new_node->master_keys != NULL) {
-				sodium_free_and_null(new_node->master_keys);
+				sodium_free_and_null_if_valid(new_node->master_keys);
 			}
 
-			sodium_free_and_null(new_node);
+			sodium_free_and_null_if_valid(new_node);
 		}
-	}
+	)
 
 	return status;
 }
@@ -208,11 +208,11 @@ return_status user_store_find_node(user_store_node ** const node, user_store * c
 	}
 
 cleanup:
-	if (status.status != SUCCESS) {
+	on_error(
 		if (node != NULL) {
 			*node = NULL;
 		}
-	}
+	)
 
 	return status;
 }
@@ -252,13 +252,11 @@ return_status user_store_list(buffer_t ** const list, user_store * const store) 
 	}
 
 cleanup:
-	if (status.status != SUCCESS) {
+	on_error(
 		if (list != NULL) {
-			if (*list != NULL) {
-				buffer_destroy_from_heap_and_null(*list);
-			}
+				buffer_destroy_from_heap_and_null_if_valid(*list);
 		}
-	}
+	)
 
 	return status;
 }
@@ -301,7 +299,7 @@ void user_store_remove(user_store *store, user_store_node *node) {
 		store->head = node->next;
 	}
 
-	sodium_free_and_null(node);
+	sodium_free_and_null_if_valid(node);
 
 	//update length
 	store->length--;
@@ -451,7 +449,7 @@ user_store *user_store_json_import(const mcJSON * const json) {
 	}
 
 cleanup:
-	if (status.status != SUCCESS) {
+	on_error(
 		if (store != NULL) {
 			user_store_destroy(store);
 		}
@@ -460,14 +458,12 @@ cleanup:
 			if (node->prekeys != NULL) {
 				prekey_store_destroy(node->prekeys);
 			}
-			if (node->master_keys != NULL) {
-				sodium_free_and_null(node->master_keys);
-			}
-			sodium_free_and_null(node);
+			sodium_free_and_null_if_valid(node->master_keys);
+			sodium_free_and_null_if_valid(node);
 		}
 
 		return_status_destroy_errors(&status);
-	}
+	)
 
 	return store;
 }

--- a/lib/zeroed_malloc.c
+++ b/lib/zeroed_malloc.c
@@ -71,7 +71,7 @@ void zeroed_free(void *pointer) {
 
 	sodium_memzero(pointer, size);
 
-	free_and_null(malloced_address);
+	free_and_null_if_valid(malloced_address);
 }
 
 void *protobuf_c_allocator(void *allocator_data __attribute__((unused)), size_t size) {

--- a/test/alignment-test.c
+++ b/test/alignment-test.c
@@ -40,7 +40,7 @@ int main(void) {
 cleanup:
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/chain-key-derivation-test.c
+++ b/test/chain-key-derivation-test.c
@@ -72,12 +72,12 @@ int main(void) {
 	}
 
 cleanup:
-	buffer_destroy_from_heap_and_null(last_chain_key);
-	buffer_destroy_from_heap_and_null(next_chain_key);
+	buffer_destroy_from_heap_and_null_if_valid(last_chain_key);
+	buffer_destroy_from_heap_and_null_if_valid(next_chain_key);
 
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/conversation-packet-test.c
+++ b/test/conversation-packet-test.c
@@ -225,7 +225,7 @@ int main(void) {
 	throw_on_error(GENERIC_ERROR, "Failed to get Alice' prekey list.");
 
 	//destroy the old packet
-	buffer_destroy_from_heap_and_null(packet);
+	buffer_destroy_from_heap_and_null_if_valid(packet);
 	status = conversation_start_send_conversation(
 			&bob_send_conversation,
 			send_message,
@@ -242,7 +242,7 @@ int main(void) {
 	putchar('\n');
 
 	//let alice receive the packet
-	buffer_destroy_from_heap_and_null(received_message);
+	buffer_destroy_from_heap_and_null_if_valid(received_message);
 	received_message = NULL;
 	status = conversation_start_receive_conversation(
 			&alice_receive_conversation,
@@ -341,36 +341,16 @@ cleanup:
 	if (bob_prekeys != NULL) {
 		prekey_store_destroy(bob_prekeys);
 	}
-	if (packet != NULL) {
-		buffer_destroy_from_heap_and_null(packet);
-	}
-	if (received_message != NULL) {
-		buffer_destroy_from_heap_and_null(received_message);
-	}
-	if (alice_send_packet2 != NULL) {
-		buffer_destroy_from_heap_and_null(alice_send_packet2);
-	}
-	if (bob_receive_message2 != NULL) {
-		buffer_destroy_from_heap_and_null(bob_receive_message2);
-	}
-	if (bob_send_packet2 != NULL) {
-		buffer_destroy_from_heap_and_null(bob_send_packet2);
-	}
-	if (alice_receive_message2 != NULL) {
-		buffer_destroy_from_heap_and_null(alice_receive_message2);
-	}
-	if (bob_response_packet != NULL) {
-		buffer_destroy_from_heap_and_null(bob_response_packet);
-	}
-	if (alice_received_response != NULL) {
-		buffer_destroy_from_heap_and_null(alice_received_response);
-	}
-	if (alice_response_packet != NULL) {
-		buffer_destroy_from_heap_and_null(alice_response_packet);
-	}
-	if (bob_received_response != NULL) {
-		buffer_destroy_from_heap_and_null(bob_received_response);
-	}
+	buffer_destroy_from_heap_and_null_if_valid(packet);
+	buffer_destroy_from_heap_and_null_if_valid(received_message);
+	buffer_destroy_from_heap_and_null_if_valid(alice_send_packet2);
+	buffer_destroy_from_heap_and_null_if_valid(bob_receive_message2);
+	buffer_destroy_from_heap_and_null_if_valid(bob_send_packet2);
+	buffer_destroy_from_heap_and_null_if_valid(alice_receive_message2);
+	buffer_destroy_from_heap_and_null_if_valid(bob_response_packet);
+	buffer_destroy_from_heap_and_null_if_valid(alice_received_response);
+	buffer_destroy_from_heap_and_null_if_valid(alice_response_packet);
+	buffer_destroy_from_heap_and_null_if_valid(bob_received_response);
 	if (alice_send_conversation != NULL) {
 		conversation_destroy(alice_send_conversation);
 	}
@@ -383,16 +363,16 @@ cleanup:
 	if (bob_receive_conversation != NULL) {
 		conversation_destroy(bob_receive_conversation);
 	}
-	buffer_destroy_from_heap_and_null(alice_private_identity);
-	buffer_destroy_from_heap_and_null(alice_public_identity);
-	buffer_destroy_from_heap_and_null(bob_private_identity);
-	buffer_destroy_from_heap_and_null(bob_public_identity);
-	buffer_destroy_from_heap_and_null(prekey_list);
+	buffer_destroy_from_heap_and_null_if_valid(alice_private_identity);
+	buffer_destroy_from_heap_and_null_if_valid(alice_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(bob_private_identity);
+	buffer_destroy_from_heap_and_null_if_valid(bob_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(prekey_list);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
 		return_status_destroy_errors(&status);
-	}
+	)
 
 	return status.status;
 }

--- a/test/conversation-store-test.c
+++ b/test/conversation-store-test.c
@@ -106,12 +106,12 @@ cleanup:
 		conversation_destroy(conversation);
 	}
 	//destroy all the buffers
-	buffer_destroy_from_heap_and_null(our_private_identity);
-	buffer_destroy_from_heap_and_null(our_public_identity);
-	buffer_destroy_from_heap_and_null(their_public_identity);
-	buffer_destroy_from_heap_and_null(our_private_ephemeral);
-	buffer_destroy_from_heap_and_null(our_public_ephemeral);
-	buffer_destroy_from_heap_and_null(their_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(our_private_identity);
+	buffer_destroy_from_heap_and_null_if_valid(our_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(their_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(our_private_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(our_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(their_public_ephemeral);
 
 	return status;
 }
@@ -157,7 +157,7 @@ int main(void) {
 		printf("ID of the conversation No. %zu:\n", index);
 		print_hex(value->id);
 		putchar('\n');
-	);
+	)
 
 	//find node by id
 	conversation_t *found_node = NULL;
@@ -173,7 +173,7 @@ int main(void) {
 	status = conversation_store_list(&conversation_list, store);
 	on_error(
 		throw(DATA_FETCH_ERROR, "Failed to list conversations.");
-	);
+	)
 	if ((conversation_list == NULL) || (conversation_list->content_length != (CONVERSATION_ID_SIZE * store->length))) {
 		throw(DATA_FETCH_ERROR, "Failed to get list of conversations.");
 	}
@@ -183,64 +183,64 @@ int main(void) {
 		buffer_create_with_existing_array(current_id, conversation_list->content + CONVERSATION_ID_SIZE * i, CONVERSATION_ID_SIZE);
 		status = conversation_store_find_node(&found_node, store, current_id);
 		if ((status.status != SUCCESS) || (found_node == NULL)) {
-			buffer_destroy_from_heap_and_null(conversation_list);
+			buffer_destroy_from_heap_and_null_if_valid(conversation_list);
 			throw(INCORRECT_DATA, "Exported list of conversations was incorrect.");
 		}
 	}
-	buffer_destroy_from_heap_and_null(conversation_list);
+	buffer_destroy_from_heap_and_null_if_valid(conversation_list);
 
 	//test JSON export
 	printf("Test JSON export!\n");
 	mempool_t *pool = buffer_create_on_heap(100000, 0);
 	mcJSON *json = conversation_store_json_export(store, pool);
 	if (json == NULL) {
-		buffer_destroy_from_heap_and_null(pool);
+		buffer_destroy_from_heap_and_null_if_valid(pool);
 		throw(EXPORT_ERROR, "Failed to export JSON.");
 	}
 	buffer_t *output = mcJSON_PrintBuffered(json, 4000, true);
 	if (output == NULL) {
-		buffer_destroy_from_heap_and_null(pool);
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(pool);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(GENERIC_ERROR, "Failed to print json.");
 	}
 	printf("%.*s\n", (int)output->content_length, output->content);
 	if (json->length != 5) {
-		buffer_destroy_from_heap_and_null(pool);
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(pool);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(INCORRECT_DATA, "Exported JSON doesn't contain all conversations.");
 	}
-	buffer_destroy_from_heap_and_null(pool);
+	buffer_destroy_from_heap_and_null_if_valid(pool);
 
 	//test JSON import
 	conversation_store *imported_store = malloc(sizeof(conversation_store));
 	if (imported_store == NULL) {
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(ALLOCATION_FAILED, "Failed to allocate conversation store.");
 	}
 	JSON_INITIALIZE(imported_store, 100000, output, conversation_store_json_import, status_int);
 	if (status_int != 0) {
-		free_and_null(imported_store);
-		buffer_destroy_from_heap_and_null(output);
+		free_and_null_if_valid(imported_store);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(IMPORT_ERROR, "Failed to import from JSON.");
 	}
 	//export the imported to json again
 	JSON_EXPORT(imported_output, 100000, 4000, true, imported_store, conversation_store_json_export);
 	if (imported_output == NULL) {
 		conversation_store_clear(imported_store);
-		free_and_null(imported_store);
-		buffer_destroy_from_heap_and_null(output);
+		free_and_null_if_valid(imported_store);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(GENERIC_ERROR, "Failed to print imported output.");
 	}
 	conversation_store_clear(imported_store);
-	free_and_null(imported_store);
+	free_and_null_if_valid(imported_store);
 	//compare both JSON strings
 	if (buffer_compare(imported_output, output) != 0) {
-		buffer_destroy_from_heap_and_null(output);
-		buffer_destroy_from_heap_and_null(imported_output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
+		buffer_destroy_from_heap_and_null_if_valid(imported_output);
 		throw(INCORRECT_DATA, "Imported conversation store is incorrect.");
 	}
-	buffer_destroy_from_heap_and_null(output);
-	buffer_destroy_from_heap_and_null(imported_output);
+	buffer_destroy_from_heap_and_null_if_valid(output);
+	buffer_destroy_from_heap_and_null_if_valid(imported_output);
 
 	//remove nodes
 	conversation_store_remove(store, store->head);
@@ -266,11 +266,11 @@ int main(void) {
 
 cleanup:
 	conversation_store_clear(store);
-	free_and_null(store);
+	free_and_null_if_valid(store);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
-	}
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/conversation-test.c
+++ b/test/conversation-test.c
@@ -86,11 +86,11 @@ return_status create_conversation(
 	throw_on_error(CREATION_ERROR, "Failed to create ratchet.");
 
 cleanup:
-	if (status.status != 0) {
-		if ((conversation != NULL) && (*conversation != NULL)) {
-			free_and_null(*conversation);
+	on_error(
+		if (conversation != NULL) {
+			free_and_null_if_valid(*conversation);
 		}
-	}
+	)
 
 	return status;
 }
@@ -191,15 +191,15 @@ int main(void) {
 	mempool_t *pool = buffer_create_on_heap(10000, 0);
 	mcJSON *json = conversation_json_export(charlie_conversation, pool);
 	if (json == NULL) {
-		buffer_destroy_from_heap_and_null(pool);
+		buffer_destroy_from_heap_and_null_if_valid(pool);
 		throw(EXPORT_ERROR, "Failed to export as JSON.");
 	}
 	if (json->length != 2) {
-		buffer_destroy_from_heap_and_null(pool);
+		buffer_destroy_from_heap_and_null_if_valid(pool);
 		throw(INCORRECT_DATA, "JSON for Charlie's conversation is invalid.");
 	}
 	buffer_t *output = mcJSON_PrintBuffered(json, 4000, true);
-	buffer_destroy_from_heap_and_null(pool);
+	buffer_destroy_from_heap_and_null_if_valid(pool);
 	if (output == NULL) {
 		throw(GENERIC_ERROR, "Failed to print JSON.");
 	}
@@ -208,23 +208,23 @@ int main(void) {
 	//test JSON import
 	JSON_IMPORT(imported_charlies_conversation, 10000, output, conversation_json_import);
 	if (imported_charlies_conversation == NULL) {
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(IMPORT_ERROR, "Failed to import Charlie's conversation from JSON.");
 	}
 	//export the imported to JSON again
 	JSON_EXPORT(imported_output, 10000, 4000, true, imported_charlies_conversation, conversation_json_export);
 	if (imported_output == NULL) {
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(EXPORT_ERROR, "Failed to export Charlie's imported conversation as JSON.");
 	}
 	//compare with original JSON
 	if (buffer_compare(imported_output, output) != 0) {
-		buffer_destroy_from_heap_and_null(imported_output);
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(imported_output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(INCORRECT_DATA, "Imported conversation is incorrect.");
 	}
-	buffer_destroy_from_heap_and_null(imported_output);
-	buffer_destroy_from_heap_and_null(output);
+	buffer_destroy_from_heap_and_null_if_valid(imported_output);
+	buffer_destroy_from_heap_and_null_if_valid(output);
 
 cleanup:
 	if (charlie_conversation != NULL) {
@@ -237,18 +237,18 @@ cleanup:
 		conversation_destroy(imported_charlies_conversation);
 	}
 
-	buffer_destroy_from_heap_and_null(charlie_private_identity);
-	buffer_destroy_from_heap_and_null(charlie_public_identity);
-	buffer_destroy_from_heap_and_null(charlie_private_ephemeral);
-	buffer_destroy_from_heap_and_null(charlie_public_ephemeral);
-	buffer_destroy_from_heap_and_null(dora_private_identity);
-	buffer_destroy_from_heap_and_null(dora_public_identity);
-	buffer_destroy_from_heap_and_null(dora_private_ephemeral);
-	buffer_destroy_from_heap_and_null(dora_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(charlie_private_identity);
+	buffer_destroy_from_heap_and_null_if_valid(charlie_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(charlie_private_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(charlie_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(dora_private_identity);
+	buffer_destroy_from_heap_and_null_if_valid(dora_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(dora_private_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(dora_public_ephemeral);
 
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/diffie-hellman-test.c
+++ b/test/diffie-hellman-test.c
@@ -104,16 +104,16 @@ int main(void) {
 	printf("Both shared secrets match!\n");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(alice_public_key);
-	buffer_destroy_from_heap_and_null(alice_private_key);
-	buffer_destroy_from_heap_and_null(alice_shared_secret);
-	buffer_destroy_from_heap_and_null(bob_public_key);
-	buffer_destroy_from_heap_and_null(bob_private_key);
-	buffer_destroy_from_heap_and_null(bob_shared_secret);
+	buffer_destroy_from_heap_and_null_if_valid(alice_public_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_private_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_shared_secret);
+	buffer_destroy_from_heap_and_null_if_valid(bob_public_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_private_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_shared_secret);
 
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/endianness-test.c
+++ b/test/endianness-test.c
@@ -135,12 +135,12 @@ int main(void) {
 	printf("Successfully converted back!\n\n");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(buffer64);
-	buffer_destroy_from_heap_and_null(buffer32);
+	buffer_destroy_from_heap_and_null_if_valid(buffer64);
+	buffer_destroy_from_heap_and_null_if_valid(buffer32);
 
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/header-and-message-keystore-test.c
+++ b/test/header-and-message-keystore-test.c
@@ -88,7 +88,7 @@ int main(void) {
 	printf("Test JSON export!\n");
 	JSON_EXPORT(output, 10000, 500, true, &keystore, header_and_message_keystore_json_export);
 	if (output == NULL) {
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		header_and_message_keystore_clear(&keystore);
 		throw(EXPORT_ERROR, "Failed to export to JSON.");
 	}
@@ -98,13 +98,13 @@ int main(void) {
 	header_and_message_keystore imported_keystore;
 	JSON_INITIALIZE(&imported_keystore, 10000, output, header_and_message_keystore_json_import, status_int);
 	if (status_int != 0) {
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(IMPORT_ERROR, "Failed to import keystore from JSON.");
 	}
 	//export the imported JSON to JSON again
 	JSON_EXPORT(imported_output, 10000, 500, true, &imported_keystore, header_and_message_keystore_json_export);
 	if (imported_output == NULL) {
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		header_and_message_keystore_clear(&keystore);
 		header_and_message_keystore_clear(&imported_keystore);
 		throw(EXPORT_ERROR, "Failed to export from imported JSON.");
@@ -112,13 +112,13 @@ int main(void) {
 	//compare with original JSON
 	if (buffer_compare(imported_output, output) != 0) {
 		header_and_message_keystore_clear(&imported_keystore);
-		buffer_destroy_from_heap_and_null(output);
-		buffer_destroy_from_heap_and_null(imported_output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
+		buffer_destroy_from_heap_and_null_if_valid(imported_output);
 		throw(INCORRECT_DATA, "Imported header and message keystore is incorrect.");
 	}
 	printf("Successfully imported header and message keystore from JSON.\n");
-	buffer_destroy_from_heap_and_null(imported_output);
-	buffer_destroy_from_heap_and_null(output);
+	buffer_destroy_from_heap_and_null_if_valid(imported_output);
+	buffer_destroy_from_heap_and_null_if_valid(output);
 
 	//remove key from the head
 	printf("Remove head!\n");
@@ -139,8 +139,8 @@ int main(void) {
 	print_header_and_message_keystore(&keystore);
 
 cleanup:
-	buffer_destroy_from_heap_and_null(header_key);
-	buffer_destroy_from_heap_and_null(message_key);
+	buffer_destroy_from_heap_and_null_if_valid(header_key);
+	buffer_destroy_from_heap_and_null_if_valid(message_key);
 
 	header_and_message_keystore_clear(&keystore);
 
@@ -154,7 +154,7 @@ cleanup:
 
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/header-test.c
+++ b/test/header-test.c
@@ -101,17 +101,14 @@ int main(void) {
 	printf("Previous message numbers match.\n");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(our_public_ephemeral_key);
-	buffer_destroy_from_heap_and_null(extracted_public_ephemeral_key);
+	buffer_destroy_from_heap_and_null_if_valid(our_public_ephemeral_key);
+	buffer_destroy_from_heap_and_null_if_valid(extracted_public_ephemeral_key);
+	buffer_destroy_from_heap_and_null_if_valid(header);
 
-	if (header != NULL) {
-		buffer_destroy_from_heap_and_null(header);
-	}
-
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
 		return_status_destroy_errors(&status);
-	}
+	)
 
 	return status.status;
 }

--- a/test/initial-root-chain-and-header-key-derivation-test.c
+++ b/test/initial-root-chain-and-header-key-derivation-test.c
@@ -239,33 +239,33 @@ int main(void) {
 
 cleanup:
 	//alice keys
-	buffer_destroy_from_heap_and_null(alice_public_identity);
-	buffer_destroy_from_heap_and_null(alice_private_identity);
-	buffer_destroy_from_heap_and_null(alice_public_ephemeral);
-	buffer_destroy_from_heap_and_null(alice_private_ephemeral);
-	buffer_destroy_from_heap_and_null(alice_root_key);
-	buffer_destroy_from_heap_and_null(alice_send_chain_key);
-	buffer_destroy_from_heap_and_null(alice_receive_chain_key);
-	buffer_destroy_from_heap_and_null(alice_send_header_key);
-	buffer_destroy_from_heap_and_null(alice_receive_header_key);
-	buffer_destroy_from_heap_and_null(alice_next_send_header_key);
-	buffer_destroy_from_heap_and_null(alice_next_receive_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(alice_private_identity);
+	buffer_destroy_from_heap_and_null_if_valid(alice_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(alice_private_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(alice_root_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_send_chain_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_receive_chain_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_send_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_receive_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_next_send_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_next_receive_header_key);
 	//bobs keys
-	buffer_destroy_from_heap_and_null(bob_public_identity);
-	buffer_destroy_from_heap_and_null(bob_private_identity);
-	buffer_destroy_from_heap_and_null(bob_public_ephemeral);
-	buffer_destroy_from_heap_and_null(bob_private_ephemeral);
-	buffer_destroy_from_heap_and_null(bob_root_key);
-	buffer_destroy_from_heap_and_null(bob_send_chain_key);
-	buffer_destroy_from_heap_and_null(bob_receive_chain_key);
-	buffer_destroy_from_heap_and_null(bob_send_header_key);
-	buffer_destroy_from_heap_and_null(bob_receive_header_key);
-	buffer_destroy_from_heap_and_null(bob_next_send_header_key);
-	buffer_destroy_from_heap_and_null(bob_next_receive_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(bob_private_identity);
+	buffer_destroy_from_heap_and_null_if_valid(bob_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(bob_private_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(bob_root_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_send_chain_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_receive_chain_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_send_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_receive_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_next_send_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_next_receive_header_key);
 
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/key-derivation-test.c
+++ b/test/key-derivation-test.c
@@ -74,14 +74,14 @@ int main(void) {
 	}
 
 cleanup:
-	buffer_destroy_from_heap_and_null(master_key);
-	buffer_destroy_from_heap_and_null(subkey1);
-	buffer_destroy_from_heap_and_null(subkey2);
-	buffer_destroy_from_heap_and_null(subkey1_copy);
+	buffer_destroy_from_heap_and_null_if_valid(master_key);
+	buffer_destroy_from_heap_and_null_if_valid(subkey1);
+	buffer_destroy_from_heap_and_null_if_valid(subkey2);
+	buffer_destroy_from_heap_and_null_if_valid(subkey1_copy);
 
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/master-keys-test.c
+++ b/test/master-keys-test.c
@@ -154,7 +154,7 @@ int main(void) {
 	//import it again
 	JSON_IMPORT(imported_master_keys, 10000, json_string1, master_keys_json_import);
 	if (imported_master_keys == NULL) {
-		buffer_destroy_from_heap_and_null(json_string1);
+		buffer_destroy_from_heap_and_null_if_valid(json_string1);
 		throw(IMPORT_ERROR, "Failed to import from JSON.")
 	}
 	printf("Successfully imported from JSON!\n");
@@ -162,41 +162,35 @@ int main(void) {
 	//export it again
 	JSON_EXPORT(exported_json_string, 10000, 500, true, imported_master_keys, master_keys_json_export);
 	if (exported_json_string == NULL) {
-		buffer_destroy_from_heap_and_null(json_string1);
+		buffer_destroy_from_heap_and_null_if_valid(json_string1);
 		throw(EXPORT_ERROR, "Failed to export imported back to JSON.");
 	}
 	printf("Successfully exported back to JSON!\n");
 
 	//compare them
 	if (buffer_compare(json_string1, exported_json_string) != 0) {
-		buffer_destroy_from_heap_and_null(json_string1);
-		buffer_destroy_from_heap_and_null(exported_json_string);
+		buffer_destroy_from_heap_and_null_if_valid(json_string1);
+		buffer_destroy_from_heap_and_null_if_valid(exported_json_string);
 		throw(INCORRECT_DATA, "Object imported from JSON was incorrect.");
 	}
 	printf("Imported Object matches!\n");
 
-	buffer_destroy_from_heap_and_null(json_string1);
-	buffer_destroy_from_heap_and_null(exported_json_string);
+	buffer_destroy_from_heap_and_null_if_valid(json_string1);
+	buffer_destroy_from_heap_and_null_if_valid(exported_json_string);
 
 cleanup:
-	if (unspiced_master_keys != NULL) {
-		sodium_free_and_null(unspiced_master_keys);
-	}
-	if (spiced_master_keys != NULL) {
-		sodium_free_and_null(spiced_master_keys);
-	}
-	if (imported_master_keys != NULL) {
-		sodium_free_and_null(imported_master_keys);
-	}
+	sodium_free_and_null_if_valid(unspiced_master_keys);
+	sodium_free_and_null_if_valid(spiced_master_keys);
+	sodium_free_and_null_if_valid(imported_master_keys);
 
-	buffer_destroy_from_heap_and_null(public_signing_key);
-	buffer_destroy_from_heap_and_null(public_identity_key);
-	buffer_destroy_from_heap_and_null(signed_data);
-	buffer_destroy_from_heap_and_null(unwrapped_data);
+	buffer_destroy_from_heap_and_null_if_valid(public_signing_key);
+	buffer_destroy_from_heap_and_null_if_valid(public_identity_key);
+	buffer_destroy_from_heap_and_null_if_valid(signed_data);
+	buffer_destroy_from_heap_and_null_if_valid(unwrapped_data);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
-	}
+	)
 	return_status_destroy_errors(&status);
 
 	if (status_int != 0) {

--- a/test/message-key-derivation-test.c
+++ b/test/message-key-derivation-test.c
@@ -60,12 +60,12 @@ int main(void) {
 	putchar('\n');
 
 cleanup:
-	buffer_destroy_from_heap_and_null(chain_key);
-	buffer_destroy_from_heap_and_null(message_key);
+	buffer_destroy_from_heap_and_null_if_valid(chain_key);
+	buffer_destroy_from_heap_and_null_if_valid(message_key);
 
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/molch-init-test.c
+++ b/test/molch-init-test.c
@@ -98,25 +98,17 @@ int main(void) {
 	print_to_file(backup_key_buffer, "molch-init-backup.key");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(user_id);
-	if (backup != NULL) {
-		free_and_null(backup);
-	}
-	if (prekey_list != NULL) {
-		free_and_null(prekey_list);
-	}
-	if (backup_file != NULL) {
-		buffer_destroy_from_heap_and_null(backup_file);
-	}
-	if (backup_key_file != NULL) {
-		buffer_destroy_from_heap_and_null(backup_key_file);
-	}
+	buffer_destroy_from_heap_and_null_if_valid(user_id);
+	free_and_null_if_valid(backup);
+	free_and_null_if_valid(prekey_list);
+	buffer_destroy_from_heap_and_null_if_valid(backup_file);
+	buffer_destroy_from_heap_and_null_if_valid(backup_key_file);
 
-	free_and_null(backup_key);
+	free_and_null_if_valid(backup_key);
 
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/molch-test.c
+++ b/test/molch-test.c
@@ -75,7 +75,7 @@ int main(void) {
 	unsigned char *empty_backup= NULL;
 	status = molch_export(&empty_backup, &empty_backup_length);
 	throw_on_error(EXPORT_ERROR, "Failed to export empty library.");
-	free_and_null(empty_backup);
+	free_and_null_if_valid(empty_backup);
 	if (empty_backup_length != (sizeof("[]") + BACKUP_NONCE_SIZE + crypto_secretbox_MACBYTES)) {
 		throw(INCORRECT_DATA, "Incorrect output length when there is no user.");
 	}
@@ -116,7 +116,7 @@ int main(void) {
 	if (complete_export == NULL) {
 		throw(EXPORT_ERROR, "Failed to export the librarys state as JSON after creating alice.");
 	}
-	free_and_null(complete_export);
+	free_and_null_if_valid(complete_export);
 
 
 	//check user count
@@ -165,10 +165,10 @@ int main(void) {
 	if ((user_count != 2)
 			|| (sodium_memcmp(alice_public_identity->content, user_list, alice_public_identity->content_length) != 0)
 			|| (sodium_memcmp(bob_public_identity->content, user_list + crypto_box_PUBLICKEYBYTES, alice_public_identity->content_length) != 0)) {
-		free_and_null(user_list);
+		free_and_null_if_valid(user_list);
 		throw(INCORRECT_DATA, "User list is incorrect.");
 	}
-	free_and_null(user_list);
+	free_and_null_if_valid(user_list);
 
 	//create a new send conversation (alice sends to bob)
 	buffer_create_from_string(alice_send_message, "Hi Bob. Alice here!");
@@ -202,22 +202,20 @@ int main(void) {
 			alice_public_identity->content_length);
 	throw_on_error(GENERIC_ERROR, "Failed to list conversations.");
 	if ((number_of_conversations != 1) || (buffer_compare_to_raw(alice_conversation, conversation_list, alice_conversation->content_length) != 0)) {
-		free_and_null(conversation_list);
+		free_and_null_if_valid(conversation_list);
 		throw(GENERIC_ERROR, "Failed to list conversations.");
 	}
-	free_and_null(conversation_list);
+	free_and_null_if_valid(conversation_list);
 
 	//check the message type
 	if (molch_get_message_type(alice_send_packet, alice_send_packet_length) != PREKEY_MESSAGE) {
 		throw(INVALID_VALUE, "Wrong message type.");
 	}
 
-	if (bob_public_prekeys != NULL) {
-		free_and_null(bob_public_prekeys);
-	}
+	free_and_null_if_valid(bob_public_prekeys);
 
 	// delete
-	free_and_null(alice_public_prekeys);
+	free_and_null_if_valid(alice_public_prekeys);
 
 	// export the prekeys again
 	status = molch_get_prekey_list(
@@ -252,10 +250,10 @@ int main(void) {
 	printf("received (Bob): %s\n", bob_receive_message);
 	if ((alice_send_message->content_length != bob_receive_message_length)
 			|| (sodium_memcmp(alice_send_message->content, bob_receive_message, bob_receive_message_length) != 0)) {
-		free_and_null(bob_receive_message);
+		free_and_null_if_valid(bob_receive_message);
 		throw(GENERIC_ERROR, "Incorrect message received.");
 	}
-	free_and_null(bob_receive_message);
+	free_and_null_if_valid(bob_receive_message);
 
 	//bob replies
 	buffer_create_from_string(bob_send_message, "Welcome Alice!");
@@ -276,7 +274,7 @@ int main(void) {
 	if (conversation_json_export == NULL) {
 		throw(EXPORT_ERROR, "Failed to export the conversation after encrypting a message.");
 	}
-	free_and_null(conversation_json_export);
+	free_and_null_if_valid(conversation_json_export);
 
 	//check the message type
 	if (molch_get_message_type(bob_send_packet, bob_send_packet_length) != NORMAL_MESSAGE) {
@@ -298,14 +296,12 @@ int main(void) {
 			NULL,
 			NULL);
 	on_error(
-		if (alice_receive_message != NULL) {
-			free_and_null(alice_receive_message);
-		}
+		free_and_null_if_valid(alice_receive_message);
 		throw(GENERIC_ERROR, "Incorrect message received.");
 	)
 
 	if ((alice_receive_message_number != 0) || (alice_previous_receive_message_number != 0)) {
-		free_and_null(alice_receive_message);
+		free_and_null_if_valid(alice_receive_message);
 		throw(INCORRECT_DATA, "Incorrect receive message number for Alice.");
 	}
 
@@ -314,10 +310,10 @@ int main(void) {
 	printf("received (Alice): %s\n", alice_receive_message);
 	if ((bob_send_message->content_length != alice_receive_message_length)
 			|| (sodium_memcmp(bob_send_message->content, alice_receive_message, alice_receive_message_length) != 0)) {
-		free_and_null(alice_receive_message);
+		free_and_null_if_valid(alice_receive_message);
 		throw(GENERIC_ERROR, "Incorrect message received.");
 	}
-	free_and_null(alice_receive_message);
+	free_and_null_if_valid(alice_receive_message);
 
 	//test export
 	printf("Test export!\n");
@@ -336,7 +332,7 @@ int main(void) {
 			backup_key->content,
 			backup_key->content_length);
 	on_error(
-		free_and_null(backup);
+		free_and_null_if_valid(backup);
 		throw(IMPORT_ERROR, "Failed to import backup.");
 	)
 
@@ -367,7 +363,7 @@ int main(void) {
 	unsigned char *imported_backup = NULL;
 	status = molch_export(&imported_backup, &imported_backup_length);
 	on_error(
-		free_and_null(backup);
+		free_and_null_if_valid(backup);
 		throw(EXPORT_ERROR, "Failed to export imported backup.");
 	)
 
@@ -385,12 +381,12 @@ int main(void) {
 
 	//compare
 	if ((backup_length != imported_backup_length) || (sodium_memcmp(backup, imported_backup, backup_length) != 0)) {
-		free_and_null(backup);
-		free_and_null(imported_backup);
+		free_and_null_if_valid(backup);
+		free_and_null_if_valid(imported_backup);
 		throw(IMPORT_ERROR, "Imported backup is incorrect.");
 	}
-	free_and_null(backup);
-	free_and_null(imported_backup);
+	free_and_null_if_valid(backup);
+	free_and_null_if_valid(imported_backup);
 
 	//test conversation export
 	status = molch_conversation_export(
@@ -411,7 +407,7 @@ int main(void) {
 			backup_key->content,
 			backup_key->content_length);
 	on_error(
-		free_and_null(backup);
+		free_and_null_if_valid(backup);
 		throw(IMPORT_ERROR, "Failed to import Alice' conversation from backup.");
 	)
 
@@ -440,7 +436,7 @@ int main(void) {
 			alice_conversation->content,
 			alice_conversation->content_length);
 	on_error(
-		free_and_null(backup);
+		free_and_null_if_valid(backup);
 		throw(EXPORT_ERROR, "Failed to export Alice imported conversation.");
 	)
 
@@ -458,13 +454,13 @@ int main(void) {
 
 	//compare
 	if ((backup_length != imported_backup_length) || (sodium_memcmp(backup, imported_backup, backup_length) != 0)) {
-		free_and_null(backup);
-		free_and_null(imported_backup);
+		free_and_null_if_valid(backup);
+		free_and_null_if_valid(imported_backup);
 		throw(IMPORT_ERROR, "JSON of imported conversation is incorrect.");
 	}
 
-	free_and_null(imported_backup);
-	free_and_null(backup);
+	free_and_null_if_valid(imported_backup);
+	free_and_null_if_valid(backup);
 
 	//destroy the conversations
 	molch_end_conversation(alice_conversation->content, alice_conversation->content_length, NULL, NULL);
@@ -488,32 +484,22 @@ int main(void) {
 	}
 
 cleanup:
-	if (alice_public_prekeys != NULL) {
-		free_and_null(alice_public_prekeys);
-	}
-	if (bob_public_prekeys != NULL) {
-		free_and_null(bob_public_prekeys);
-	}
-	if (alice_send_packet != NULL) {
-		free_and_null(alice_send_packet);
-	}
-	if (bob_send_packet != NULL) {
-		free_and_null(bob_send_packet);
-	}
-	if (printed_status != NULL) {
-		free_and_null(printed_status);
-	}
+	free_and_null_if_valid(alice_public_prekeys);
+		free_and_null_if_valid(bob_public_prekeys);
+		free_and_null_if_valid(alice_send_packet);
+		free_and_null_if_valid(bob_send_packet);
+		free_and_null_if_valid(printed_status);
 	molch_destroy_all_users();
-	buffer_destroy_from_heap_and_null(alice_conversation);
-	buffer_destroy_from_heap_and_null(bob_conversation);
-	buffer_destroy_from_heap_and_null(alice_public_identity);
-	buffer_destroy_from_heap_and_null(bob_public_identity);
-	buffer_destroy_from_heap_and_null(backup_key);
-	buffer_destroy_from_heap_and_null(new_backup_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_conversation);
+	buffer_destroy_from_heap_and_null_if_valid(bob_conversation);
+	buffer_destroy_from_heap_and_null_if_valid(alice_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(bob_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(backup_key);
+	buffer_destroy_from_heap_and_null_if_valid(new_backup_key);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
-	}
+	)
 	return_status_destroy_errors(&status);
 
 	if (status_int != 0) {

--- a/test/packet-decrypt-header-test.c
+++ b/test/packet-decrypt-header-test.c
@@ -145,7 +145,7 @@ int main(void) {
 		throw(KEYGENERATION_FAILED, "Failed to generate public prekey.");
 	}
 
-	buffer_destroy_from_heap_and_null(packet);
+	buffer_destroy_from_heap_and_null_if_valid(packet);
 
 	packet_type = PREKEY_MESSAGE;
 	status = create_and_print_message(
@@ -179,23 +179,19 @@ int main(void) {
 	printf("Decrypted header matches.\n");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(header_key);
-	buffer_destroy_from_heap_and_null(message_key);
-	buffer_destroy_from_heap_and_null(header);
-	buffer_destroy_from_heap_and_null(public_identity_key);
-	buffer_destroy_from_heap_and_null(public_ephemeral_key);
-	buffer_destroy_from_heap_and_null(public_prekey);
-	if (packet != NULL) {
-		buffer_destroy_from_heap_and_null(packet);
-	}
-	if (decrypted_header != NULL) {
-		buffer_destroy_from_heap_and_null(decrypted_header);
-	}
+	buffer_destroy_from_heap_and_null_if_valid(header_key);
+	buffer_destroy_from_heap_and_null_if_valid(message_key);
+	buffer_destroy_from_heap_and_null_if_valid(header);
+	buffer_destroy_from_heap_and_null_if_valid(public_identity_key);
+	buffer_destroy_from_heap_and_null_if_valid(public_ephemeral_key);
+	buffer_destroy_from_heap_and_null_if_valid(public_prekey);
+	buffer_destroy_from_heap_and_null_if_valid(packet);
+	buffer_destroy_from_heap_and_null_if_valid(decrypted_header);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
-		return_status_destroy_errors(&status);
-	}
+	)
+	return_status_destroy_errors(&status);
 
 	return status.status;
 }

--- a/test/packet-decrypt-message-test.c
+++ b/test/packet-decrypt-message-test.c
@@ -96,7 +96,7 @@ int main(void) {
 	packet->content[packet->content_length - crypto_secretbox_MACBYTES - 1] ^= 0xf0;
 	printf("Manipulating message.\n");
 
-	buffer_destroy_from_heap_and_null(decrypted_message);
+	buffer_destroy_from_heap_and_null_if_valid(decrypted_message);
 
 	//try to decrypt
 	status = packet_decrypt_message(
@@ -126,7 +126,7 @@ int main(void) {
 		throw(KEYGENERATION_FAILED, "Failed to generate public prekey.");
 	}
 
-	buffer_destroy_from_heap_and_null(packet);
+	buffer_destroy_from_heap_and_null_if_valid(packet);
 
 	packet_type = PREKEY_MESSAGE;
 	status = create_and_print_message(
@@ -161,23 +161,19 @@ int main(void) {
 	printf("Decrypted message is the same.\n");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(header_key);
-	buffer_destroy_from_heap_and_null(message_key);
-	buffer_destroy_from_heap_and_null(header);
-	if (packet != NULL) {
-		buffer_destroy_from_heap_and_null(packet);
-	}
-	if (decrypted_message != NULL) {
-		buffer_destroy_from_heap_and_null(decrypted_message);
-	}
-	buffer_destroy_from_heap_and_null(public_identity_key);
-	buffer_destroy_from_heap_and_null(public_ephemeral_key);
-	buffer_destroy_from_heap_and_null(public_prekey);
+	buffer_destroy_from_heap_and_null_if_valid(header_key);
+	buffer_destroy_from_heap_and_null_if_valid(message_key);
+	buffer_destroy_from_heap_and_null_if_valid(header);
+	buffer_destroy_from_heap_and_null_if_valid(packet);
+	buffer_destroy_from_heap_and_null_if_valid(decrypted_message);
+	buffer_destroy_from_heap_and_null_if_valid(public_identity_key);
+	buffer_destroy_from_heap_and_null_if_valid(public_ephemeral_key);
+	buffer_destroy_from_heap_and_null_if_valid(public_prekey);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
-		return_status_destroy_errors(&status);
-	}
+	)
+	return_status_destroy_errors(&status);
 
 	return status.status;
 }

--- a/test/packet-decrypt-test.c
+++ b/test/packet-decrypt-test.c
@@ -141,9 +141,9 @@ int main(void) {
 		throw(KEYGENERATION_FAILED, "Failed to generate public prekey.");
 	}
 
-	buffer_destroy_from_heap_and_null(decrypted_header);
-	buffer_destroy_from_heap_and_null(decrypted_message);
-	buffer_destroy_from_heap_and_null(packet);
+	buffer_destroy_from_heap_and_null_if_valid(decrypted_header);
+	buffer_destroy_from_heap_and_null_if_valid(decrypted_message);
+	buffer_destroy_from_heap_and_null_if_valid(packet);
 
 	packet_type = PREKEY_MESSAGE;
 
@@ -219,29 +219,23 @@ int main(void) {
 	printf("Extracted public prekey matches!\n");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(header_key);
-	buffer_destroy_from_heap_and_null(message_key);
-	buffer_destroy_from_heap_and_null(header);
-	if (packet != NULL) {
-		buffer_destroy_from_heap_and_null(packet);
-	}
-	if (decrypted_header != NULL) {
-		buffer_destroy_from_heap_and_null(decrypted_header);
-	}
-	if (decrypted_message != NULL) {
-		buffer_destroy_from_heap_and_null(decrypted_message);
-	}
-	buffer_destroy_from_heap_and_null(public_identity_key);
-	buffer_destroy_from_heap_and_null(public_ephemeral_key);
-	buffer_destroy_from_heap_and_null(public_prekey);
-	buffer_destroy_from_heap_and_null(extracted_public_identity_key);
-	buffer_destroy_from_heap_and_null(extracted_public_ephemeral_key);
-	buffer_destroy_from_heap_and_null(extracted_public_prekey);
+	buffer_destroy_from_heap_and_null_if_valid(header_key);
+	buffer_destroy_from_heap_and_null_if_valid(message_key);
+	buffer_destroy_from_heap_and_null_if_valid(header);
+	buffer_destroy_from_heap_and_null_if_valid(packet);
+	buffer_destroy_from_heap_and_null_if_valid(decrypted_header);
+	buffer_destroy_from_heap_and_null_if_valid(decrypted_message);
+	buffer_destroy_from_heap_and_null_if_valid(public_identity_key);
+	buffer_destroy_from_heap_and_null_if_valid(public_ephemeral_key);
+	buffer_destroy_from_heap_and_null_if_valid(public_prekey);
+	buffer_destroy_from_heap_and_null_if_valid(extracted_public_identity_key);
+	buffer_destroy_from_heap_and_null_if_valid(extracted_public_ephemeral_key);
+	buffer_destroy_from_heap_and_null_if_valid(extracted_public_prekey);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
-		return_status_destroy_errors(&status);
-	}
+	)
+	return_status_destroy_errors(&status);
 
 	return status.status;
 }

--- a/test/packet-get-metadata-test.c
+++ b/test/packet-get-metadata-test.c
@@ -119,7 +119,7 @@ int main(void) {
 		throw(KEYGENERATION_FAILED, "Failed to generate public prekey.");
 	}
 
-	buffer_destroy_from_heap_and_null(packet);
+	buffer_destroy_from_heap_and_null_if_valid(packet);
 
 	packet_type = PREKEY_MESSAGE;
 	status = create_and_print_message(
@@ -177,23 +177,21 @@ int main(void) {
 	printf("Extracted public prekey matches!\n");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(header_key);
-	buffer_destroy_from_heap_and_null(message_key);
-	buffer_destroy_from_heap_and_null(header);
-	if (packet != NULL) {
-		buffer_destroy_from_heap_and_null(packet);
-	}
-	buffer_destroy_from_heap_and_null(public_identity_key);
-	buffer_destroy_from_heap_and_null(public_ephemeral_key);
-	buffer_destroy_from_heap_and_null(public_prekey);
-	buffer_destroy_from_heap_and_null(extracted_public_identity_key);
-	buffer_destroy_from_heap_and_null(extracted_public_ephemeral_key);
-	buffer_destroy_from_heap_and_null(extracted_public_prekey);
+	buffer_destroy_from_heap_and_null_if_valid(header_key);
+	buffer_destroy_from_heap_and_null_if_valid(message_key);
+	buffer_destroy_from_heap_and_null_if_valid(header);
+	buffer_destroy_from_heap_and_null_if_valid(packet);
+	buffer_destroy_from_heap_and_null_if_valid(public_identity_key);
+	buffer_destroy_from_heap_and_null_if_valid(public_ephemeral_key);
+	buffer_destroy_from_heap_and_null_if_valid(public_prekey);
+	buffer_destroy_from_heap_and_null_if_valid(extracted_public_identity_key);
+	buffer_destroy_from_heap_and_null_if_valid(extracted_public_ephemeral_key);
+	buffer_destroy_from_heap_and_null_if_valid(extracted_public_prekey);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
-		return_status_destroy_errors(&status);
-	}
+	)
+	return_status_destroy_errors(&status);
 
 	return status.status;
 }

--- a/test/packet-test-lib.c
+++ b/test/packet-test-lib.c
@@ -96,10 +96,10 @@ return_status create_and_print_message(
 	putchar('\n');
 
 cleanup:
-	if (status.status != SUCCESS) {
+	on_error(
 		buffer_clear(header_key);
 		buffer_clear(message_key);
-	}
+	)
 
 	return status;
 }

--- a/test/prekey-store-test.c
+++ b/test/prekey-store-test.c
@@ -121,26 +121,26 @@ int main(void) {
 	//Import it again
 	JSON_IMPORT(store, 100000, json_string, prekey_store_json_import);
 	if (store == NULL) {
-		buffer_destroy_from_heap_and_null(json_string);
+		buffer_destroy_from_heap_and_null_if_valid(json_string);
 		throw(IMPORT_ERROR, "Failed to import from JSON.");
 	}
 
 	//Export it again
 	JSON_EXPORT(json_string2, 100000, 10000, true, store, prekey_store_json_export);
 	if (json_string2 == NULL) {
-		buffer_destroy_from_heap_and_null(json_string);
+		buffer_destroy_from_heap_and_null_if_valid(json_string);
 		throw(EXPORT_ERROR, "Failed to export imported JSON.");
 	}
 
 	//compare both
 	if (buffer_compare(json_string, json_string2) != 0) {
-		buffer_destroy_from_heap_and_null(json_string);
-		buffer_destroy_from_heap_and_null(json_string2);
+		buffer_destroy_from_heap_and_null_if_valid(json_string);
+		buffer_destroy_from_heap_and_null_if_valid(json_string2);
 		throw(INCORRECT_DATA, "Imported JSON is incorrect.");
 	}
 
-	buffer_destroy_from_heap_and_null(json_string);
-	buffer_destroy_from_heap_and_null(json_string2);
+	buffer_destroy_from_heap_and_null_if_valid(json_string);
+	buffer_destroy_from_heap_and_null_if_valid(json_string2);
 
 	//test the automatic deprecation of old keys
 	if (buffer_clone(public_prekey, store->prekeys[PREKEY_AMOUNT-1].public_key) != 0) {
@@ -175,15 +175,15 @@ int main(void) {
 	printf("Successfully removed outdated deprecated key!\n");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(public_prekey);
-	buffer_destroy_from_heap_and_null(private_prekey1);
-	buffer_destroy_from_heap_and_null(private_prekey2);
-	buffer_destroy_from_heap_and_null(prekey_list);
+	buffer_destroy_from_heap_and_null_if_valid(public_prekey);
+	buffer_destroy_from_heap_and_null_if_valid(private_prekey1);
+	buffer_destroy_from_heap_and_null_if_valid(private_prekey2);
+	buffer_destroy_from_heap_and_null_if_valid(prekey_list);
 	prekey_store_destroy(store);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
-	}
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/ratchet-test-simple.c
+++ b/test/ratchet-test-simple.c
@@ -47,7 +47,7 @@ void export_ratchet(const ratchet_state *const ratchet, const char * const filen
 	fprintf(file, "%.*s", (int)json->content_length, json->content);
 	fclose(file);
 
-	buffer_destroy_from_heap_and_null(json);
+	buffer_destroy_from_heap_and_null_if_valid(json);
 }
 
 int main(void) {
@@ -348,21 +348,21 @@ int main(void) {
 	throw_on_error(DATA_SET_ERROR, "Bob-Roundtrip: Failed to set message authenticity.");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(alice_private_identity);
-	buffer_destroy_from_heap_and_null(alice_public_identity);
-	buffer_destroy_from_heap_and_null(alice_private_ephemeral);
-	buffer_destroy_from_heap_and_null(alice_public_ephemeral);
-	buffer_destroy_from_heap_and_null(bob_private_identity);
-	buffer_destroy_from_heap_and_null(bob_public_identity);
-	buffer_destroy_from_heap_and_null(bob_private_ephemeral);
-	buffer_destroy_from_heap_and_null(bob_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(alice_private_identity);
+	buffer_destroy_from_heap_and_null_if_valid(alice_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(alice_private_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(alice_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(bob_private_identity);
+	buffer_destroy_from_heap_and_null_if_valid(bob_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(bob_private_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(bob_public_ephemeral);
 
-	buffer_destroy_from_heap_and_null(send_header_key);
-	buffer_destroy_from_heap_and_null(send_message_key);
-	buffer_destroy_from_heap_and_null(public_send_ephemeral);
-	buffer_destroy_from_heap_and_null(current_receive_header_key);
-	buffer_destroy_from_heap_and_null(next_receive_header_key);
-	buffer_destroy_from_heap_and_null(receive_message_key);
+	buffer_destroy_from_heap_and_null_if_valid(send_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(send_message_key);
+	buffer_destroy_from_heap_and_null_if_valid(public_send_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(current_receive_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(next_receive_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(receive_message_key);
 
 	if (alice_send_ratchet != NULL) {
 		ratchet_destroy(alice_send_ratchet);
@@ -379,7 +379,7 @@ cleanup:
 
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/ratchet-test.c
+++ b/test/ratchet-test.c
@@ -199,7 +199,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_FETCH_ERROR, "Failed to get Alice's first send message key.");
-	);
+	)
 	//print the send message key
 	printf("Alice Ratchet 1 send message key 1:\n");
 	print_hex(alice_send_message_key1);
@@ -221,7 +221,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_FETCH_ERROR, "Failed to get Alice's second send message key.");
-	);
+	)
 	//print the send message key
 	printf("Alice Ratchet 1 send message key 2:\n");
 	print_hex(alice_send_message_key2);
@@ -243,7 +243,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_FETCH_ERROR, "Failed to get Alice's third send message key.");
-	);
+	)
 	//print the send message key
 	printf("Alice Ratchet 1 send message key 3:\n");
 	print_hex(alice_send_message_key3);
@@ -262,7 +262,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_FETCH_ERROR, "Failed to get Bob's receive header keys.");
-	);
+	)
 
 	printf("Bob's first current receive header key:\n");
 	print_hex(bob_current_receive_header_key);
@@ -296,7 +296,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_SET_ERROR, "Failed to set Bob's header decryptability.");
-	);
+	)
 
 	status = ratchet_receive(
 			bob_state,
@@ -308,7 +308,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(RECEIVE_ERROR, "Failed to generate Bob's first receive key.");
-	);
+	)
 	//print it out!
 	printf("Bob Ratchet 1 receive message key 1:\n");
 	print_hex(bob_receive_key1);
@@ -321,7 +321,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_SET_ERROR, "Failed to set authenticity state.");
-	);
+	)
 
 	status = ratchet_get_receive_header_keys(
 			bob_current_receive_header_key,
@@ -331,7 +331,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_FETCH_ERROR, "Failed to get Bob's header keys.");
-	);
+	)
 
 	printf("Bob's second current receive header key:\n");
 	print_hex(bob_current_receive_header_key);
@@ -362,7 +362,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_SET_ERROR, "Failed to set header decryptability.");
-	);
+	)
 
 	//second receive message key
 	status = ratchet_receive(
@@ -375,7 +375,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(RECEIVE_ERROR, "Failed to generate Bob's second receive key.");
-	);
+	)
 	//print it out!
 	printf("Bob Ratchet 1 receive message key 2:\n");
 	print_hex(bob_receive_key2);
@@ -388,7 +388,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_SET_ERROR, "Failed to set authenticity state.");
-	);
+	)
 
 	status = ratchet_get_receive_header_keys(
 			bob_current_receive_header_key,
@@ -398,7 +398,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_FETCH_ERROR, "Failed to get receive header key buffers.");
-	);
+	)
 
 	printf("Bob's third current receive header key:\n");
 	print_hex(bob_current_receive_header_key);
@@ -429,7 +429,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_SET_ERROR, "Failed to set header decryptability.");
-	);
+	)
 
 	//third receive message key
 	status = ratchet_receive(
@@ -442,7 +442,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(RECEIVE_ERROR, "Failed to generate Bob's third receive key.");
-	);
+	)
 	//print it out!
 	printf("Bob Ratchet 1 receive message key 3:\n");
 	print_hex(bob_receive_key3);
@@ -455,7 +455,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_SET_ERROR, "Failed to set authenticity state.");
-	);
+	)
 
 	//compare the message keys
 	if (buffer_compare(alice_send_message_key1, bob_receive_key1) != 0) {
@@ -504,7 +504,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_FETCH_ERROR, "Failed to get Bob's first send message key.");
-	);
+	)
 	//print the send message key
 	printf("Bob Ratchet 2 send message key 1:\n");
 	print_hex(bob_send_message_key1);
@@ -526,7 +526,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_FETCH_ERROR, "Failed to get Bob's second send message key.");
-	);
+	)
 	//print the send message key
 	printf("Bob Ratchet 2 send message key 1:\n");
 	print_hex(bob_send_message_key2);
@@ -548,7 +548,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_FETCH_ERROR, "Failed to get Bob's third send message key.");
-	);
+	)
 	//print the send message key
 	printf("Bob Ratchet 2 send message key 3:\n");
 	print_hex(bob_send_message_key3);
@@ -567,7 +567,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_FETCH_ERROR, "Failed to get Alice' receive keys.");
-	);
+	)
 
 	printf("Alice's first current receive header key:\n");
 	print_hex(alice_current_receive_header_key);
@@ -600,7 +600,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_SET_ERROR, "Failed to set header decryptability.");
-	);
+	)
 
 	status = ratchet_receive(
 			alice_state,
@@ -612,7 +612,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(RECEIVE_ERROR, "Failed to generate Alice's first receive key.");
-	);
+	)
 	//print it out
 	printf("Alice Ratchet 2 receive message key 1:\n");
 	print_hex(alice_receive_message_key1);
@@ -624,7 +624,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_SET_ERROR, "Failed to set authenticity state.");
-	);
+	)
 
 	status = ratchet_get_receive_header_keys(
 			alice_current_receive_header_key,
@@ -634,7 +634,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_FETCH_ERROR, "Failed to get Alice' receive header keys.");
-	);
+	)
 
 	printf("Alice's current receive header key:\n");
 	print_hex(alice_current_receive_header_key);
@@ -665,7 +665,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_SET_ERROR, "Failed to set header decryptability.");
-	);
+	)
 
 	//third received message key (second message skipped)
 	status = ratchet_receive(
@@ -678,7 +678,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(RECEIVE_ERROR, "Faield to generate Alice's third receive key.");
-	);
+	)
 	//print it out
 	printf("Alice Ratchet 2 receive message key 3:\n");
 	print_hex(alice_receive_message_key3);
@@ -692,7 +692,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		throw(DATA_SET_ERROR, "Failed to set authenticity state.");
-	);
+	)
 
 	assert(alice_state->staged_header_and_message_keys->length == 0);
 	assert(alice_state->skipped_header_and_message_keys->length == 1);
@@ -775,7 +775,7 @@ int main(void) {
 	if (imported_alice_state == NULL) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(IMPORT_ERROR, "Failed to import from JSON.");
 	}
 	//export the imported to JSON again
@@ -784,7 +784,7 @@ int main(void) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
 		ratchet_destroy(imported_alice_state);
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(EXPORT_ERROR, "Failed to export imported to JSON again.");
 	}
 	ratchet_destroy(imported_alice_state);
@@ -792,12 +792,12 @@ int main(void) {
 	if (buffer_compare(imported_output, output) != 0) {
 		ratchet_destroy(alice_state);
 		ratchet_destroy(bob_state);
-		buffer_destroy_from_heap_and_null(output);
-		buffer_destroy_from_heap_and_null(imported_output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
+		buffer_destroy_from_heap_and_null_if_valid(imported_output);
 		throw(INCORRECT_DATA, "Imported user store is incorrect.");
 	}
-	buffer_destroy_from_heap_and_null(imported_output);
-	buffer_destroy_from_heap_and_null(output);
+	buffer_destroy_from_heap_and_null_if_valid(imported_output);
+	buffer_destroy_from_heap_and_null_if_valid(output);
 
 
 	//destroy the ratchets again
@@ -809,52 +809,52 @@ int main(void) {
 cleanup:
 	//create all the buffers
 	//alice keys
-	buffer_destroy_from_heap_and_null(alice_private_identity);
-	buffer_destroy_from_heap_and_null(alice_public_identity);
-	buffer_destroy_from_heap_and_null(alice_private_ephemeral);
-	buffer_destroy_from_heap_and_null(alice_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(alice_private_identity);
+	buffer_destroy_from_heap_and_null_if_valid(alice_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(alice_private_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(alice_public_ephemeral);
 	//bob keys
-	buffer_destroy_from_heap_and_null(bob_private_identity);
-	buffer_destroy_from_heap_and_null(bob_public_identity);
-	buffer_destroy_from_heap_and_null(bob_private_ephemeral);
-	buffer_destroy_from_heap_and_null(bob_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(bob_private_identity);
+	buffer_destroy_from_heap_and_null_if_valid(bob_public_identity);
+	buffer_destroy_from_heap_and_null_if_valid(bob_private_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(bob_public_ephemeral);
 	//alice send message and header keys
-	buffer_destroy_from_heap_and_null(alice_send_message_key1);
-	buffer_destroy_from_heap_and_null(alice_send_header_key1);
-	buffer_destroy_from_heap_and_null(alice_send_ephemeral1);
-	buffer_destroy_from_heap_and_null(alice_send_message_key2);
-	buffer_destroy_from_heap_and_null(alice_send_header_key2);
-	buffer_destroy_from_heap_and_null(alice_send_ephemeral2);
-	buffer_destroy_from_heap_and_null(alice_send_message_key3);
-	buffer_destroy_from_heap_and_null(alice_send_header_key3);
-	buffer_destroy_from_heap_and_null(alice_send_ephemeral3);
+	buffer_destroy_from_heap_and_null_if_valid(alice_send_message_key1);
+	buffer_destroy_from_heap_and_null_if_valid(alice_send_header_key1);
+	buffer_destroy_from_heap_and_null_if_valid(alice_send_ephemeral1);
+	buffer_destroy_from_heap_and_null_if_valid(alice_send_message_key2);
+	buffer_destroy_from_heap_and_null_if_valid(alice_send_header_key2);
+	buffer_destroy_from_heap_and_null_if_valid(alice_send_ephemeral2);
+	buffer_destroy_from_heap_and_null_if_valid(alice_send_message_key3);
+	buffer_destroy_from_heap_and_null_if_valid(alice_send_header_key3);
+	buffer_destroy_from_heap_and_null_if_valid(alice_send_ephemeral3);
 	//bobs receive keys
-	buffer_destroy_from_heap_and_null(bob_current_receive_header_key);
-	buffer_destroy_from_heap_and_null(bob_next_receive_header_key);
-	buffer_destroy_from_heap_and_null(bob_receive_key1);
-	buffer_destroy_from_heap_and_null(bob_receive_key2);
-	buffer_destroy_from_heap_and_null(bob_receive_key3);
+	buffer_destroy_from_heap_and_null_if_valid(bob_current_receive_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_next_receive_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_receive_key1);
+	buffer_destroy_from_heap_and_null_if_valid(bob_receive_key2);
+	buffer_destroy_from_heap_and_null_if_valid(bob_receive_key3);
 	//bobs śend message and header keys
-	buffer_destroy_from_heap_and_null(bob_send_message_key1);
-	buffer_destroy_from_heap_and_null(bob_send_header_key1);
-	buffer_destroy_from_heap_and_null(bob_send_ephemeral1);
-	buffer_destroy_from_heap_and_null(bob_send_message_key2);
-	buffer_destroy_from_heap_and_null(bob_send_header_key2);
-	buffer_destroy_from_heap_and_null(bob_send_ephemeral2);
-	buffer_destroy_from_heap_and_null(bob_send_message_key3);
-	buffer_destroy_from_heap_and_null(bob_send_header_key3);
-	buffer_destroy_from_heap_and_null(bob_send_ephemeral3);
+	buffer_destroy_from_heap_and_null_if_valid(bob_send_message_key1);
+	buffer_destroy_from_heap_and_null_if_valid(bob_send_header_key1);
+	buffer_destroy_from_heap_and_null_if_valid(bob_send_ephemeral1);
+	buffer_destroy_from_heap_and_null_if_valid(bob_send_message_key2);
+	buffer_destroy_from_heap_and_null_if_valid(bob_send_header_key2);
+	buffer_destroy_from_heap_and_null_if_valid(bob_send_ephemeral2);
+	buffer_destroy_from_heap_and_null_if_valid(bob_send_message_key3);
+	buffer_destroy_from_heap_and_null_if_valid(bob_send_header_key3);
+	buffer_destroy_from_heap_and_null_if_valid(bob_send_ephemeral3);
 	//alice receive keys
-	buffer_destroy_from_heap_and_null(alice_current_receive_header_key);
-	buffer_destroy_from_heap_and_null(alice_next_receive_header_key);
-	buffer_destroy_from_heap_and_null(alice_receive_message_key1);
-	buffer_destroy_from_heap_and_null(alice_receive_message_key2);
-	buffer_destroy_from_heap_and_null(alice_receive_message_key3);
-	buffer_destroy_from_heap_and_null(alice_receive_header_key2);
+	buffer_destroy_from_heap_and_null_if_valid(alice_current_receive_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_next_receive_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_receive_message_key1);
+	buffer_destroy_from_heap_and_null_if_valid(alice_receive_message_key2);
+	buffer_destroy_from_heap_and_null_if_valid(alice_receive_message_key3);
+	buffer_destroy_from_heap_and_null_if_valid(alice_receive_header_key2);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
-	}
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/return-status-test.c
+++ b/test/return-status-test.c
@@ -100,17 +100,13 @@ int main(void) {
 	}
 
 cleanup:
-	if (status.error != NULL) {
+	on_error(
 		print_errors(&status);
-	}
-	if (printed_status != NULL) {
-		free_and_null(printed_status);
-	}
+	)
+	free_and_null_if_valid(printed_status);
 	return_status_destroy_errors(&status);
 
-	if (error_stack != NULL) {
-		free_and_null(error_stack);
-	}
+	free_and_null_if_valid(error_stack);
 
 	return status.status;
 }

--- a/test/root-next-header-and-chain-key-derivation-test.c
+++ b/test/root-next-header-and-chain-key-derivation-test.c
@@ -144,21 +144,21 @@ int main(void) {
 	}
 
 cleanup:
-	buffer_destroy_from_heap_and_null(alice_public_ephemeral);
-	buffer_destroy_from_heap_and_null(alice_private_ephemeral);
-	buffer_destroy_from_heap_and_null(bob_public_ephemeral);
-	buffer_destroy_from_heap_and_null(bob_private_ephemeral);
-	buffer_destroy_from_heap_and_null(previous_root_key);
-	buffer_destroy_from_heap_and_null(alice_root_key);
-	buffer_destroy_from_heap_and_null(alice_chain_key);
-	buffer_destroy_from_heap_and_null(alice_header_key);
-	buffer_destroy_from_heap_and_null(bob_root_key);
-	buffer_destroy_from_heap_and_null(bob_chain_key);
-	buffer_destroy_from_heap_and_null(bob_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(alice_private_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(bob_public_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(bob_private_ephemeral);
+	buffer_destroy_from_heap_and_null_if_valid(previous_root_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_root_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_chain_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_header_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_root_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_chain_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_header_key);
 
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/spiced-random-test.c
+++ b/test/spiced-random-test.c
@@ -73,12 +73,12 @@ int main(void) {
 	throw_on_error(GENERIC_ERROR, "Failed to generate spiced random data of length 0.");
 
 cleanup:
-	buffer_destroy_from_heap_and_null(output1);
-	buffer_destroy_from_heap_and_null(output2);
+	buffer_destroy_from_heap_and_null_if_valid(output1);
+	buffer_destroy_from_heap_and_null_if_valid(output2);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
-	}
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/triple-diffie-hellman-test.c
+++ b/test/triple-diffie-hellman-test.c
@@ -154,7 +154,7 @@ cleanup:
 
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;

--- a/test/user-store-test.c
+++ b/test/user-store-test.c
@@ -56,7 +56,7 @@ int main(void) {
 	if (list->content_length != 0) {
 		throw(INCORRECT_DATA, "List of users is not empty.");
 	}
-	buffer_destroy_from_heap_and_null(list);
+	buffer_destroy_from_heap_and_null_if_valid(list);
 
 	//create alice
 	status = user_store_create_user(
@@ -82,7 +82,7 @@ int main(void) {
 	if (buffer_compare(list, alice_public_signing_key) != 0) {
 		throw(INCORRECT_DATA, "Failed to list users.");
 	}
-	buffer_destroy_from_heap_and_null(list);
+	buffer_destroy_from_heap_and_null_if_valid(list);
 	printf("Successfully listed users.\n");
 
 	//create bob
@@ -111,7 +111,7 @@ int main(void) {
 			|| (buffer_compare_partial(list, PUBLIC_MASTER_KEY_SIZE, bob_public_signing_key, 0, PUBLIC_MASTER_KEY_SIZE) != 0)) {
 		throw(INCORRECT_DATA, "Failed to list users.");
 	}
-	buffer_destroy_from_heap_and_null(list);
+	buffer_destroy_from_heap_and_null_if_valid(list);
 	printf("Successfully listed users.\n");
 
 	//create charlie
@@ -140,7 +140,7 @@ int main(void) {
 			|| (buffer_compare_partial(list, 2 * PUBLIC_MASTER_KEY_SIZE, charlie_public_signing_key, 0, PUBLIC_MASTER_KEY_SIZE) != 0)) {
 		throw(INCORRECT_DATA, "Failed to list users.");
 	}
-	buffer_destroy_from_heap_and_null(list);
+	buffer_destroy_from_heap_and_null_if_valid(list);
 	printf("Successfully listed users.\n");
 
 	//find node
@@ -172,7 +172,7 @@ int main(void) {
 			|| (buffer_compare_partial(list, PUBLIC_MASTER_KEY_SIZE, charlie_public_signing_key, 0, PUBLIC_MASTER_KEY_SIZE) != 0)) {
 		throw(INCORRECT_DATA, "Removing user failed.");
 	}
-	buffer_destroy_from_heap_and_null(list);
+	buffer_destroy_from_heap_and_null_if_valid(list);
 	printf("Successfully removed user.\n");
 
 	//recreate bob
@@ -202,27 +202,27 @@ int main(void) {
 	mempool_t *pool = buffer_create_on_heap(200000, 0);
 	mcJSON *json = user_store_json_export(store, pool);
 	if (json == NULL) {
-		buffer_destroy_from_heap_and_null(pool);
+		buffer_destroy_from_heap_and_null_if_valid(pool);
 		throw(EXPORT_ERROR, "Failed to export to JSON.");
 	}
 	buffer_t *output = mcJSON_PrintBuffered(json, 4000, true);
 	if (output == NULL) {
-		buffer_destroy_from_heap_and_null(pool);
+		buffer_destroy_from_heap_and_null_if_valid(pool);
 		throw(EXPORT_ERROR, "Failed to print exported JSON.");
 	}
 	printf("%.*s\n", (int) output->content_length, (char*)output->content);
 	if (json->length != 2) {
-		buffer_destroy_from_heap_and_null(output);
-		buffer_destroy_from_heap_and_null(pool);
+		buffer_destroy_from_heap_and_null_if_valid(output);
+		buffer_destroy_from_heap_and_null_if_valid(pool);
 		throw(INCORRECT_DATA, "Exported JSON doesn't contain all users.");
 	}
-	buffer_destroy_from_heap_and_null(pool);
+	buffer_destroy_from_heap_and_null_if_valid(pool);
 
 	//test JSON import
 	user_store *imported_store;
 	JSON_IMPORT(imported_store, 200000, output, user_store_json_import);
 	if (imported_store == NULL) {
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(IMPORT_ERROR, "Failed to import from JSON.");
 	}
 
@@ -230,17 +230,17 @@ int main(void) {
 	JSON_EXPORT(imported_output, 200000, 4000, true, imported_store, user_store_json_export);
 	user_store_destroy(imported_store);
 	if (imported_output == NULL) {
-		buffer_destroy_from_heap_and_null(output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
 		throw(EXPORT_ERROR, "Failed to export the imported JSON again.");
 	}
 	//compare with original JSON
 	if (buffer_compare(imported_output, output) != 0) {
-		buffer_destroy_from_heap_and_null(output);
-		buffer_destroy_from_heap_and_null(imported_output);
+		buffer_destroy_from_heap_and_null_if_valid(output);
+		buffer_destroy_from_heap_and_null_if_valid(imported_output);
 		throw(INCORRECT_DATA, "Imported user store is incorrect.");
 	}
-	buffer_destroy_from_heap_and_null(output);
-	buffer_destroy_from_heap_and_null(imported_output);
+	buffer_destroy_from_heap_and_null_if_valid(output);
+	buffer_destroy_from_heap_and_null_if_valid(imported_output);
 
 	//check the user list
 	status = user_store_list(&list, store);
@@ -249,7 +249,7 @@ int main(void) {
 			|| (buffer_compare_partial(list, PUBLIC_MASTER_KEY_SIZE, charlie_public_signing_key, 0, PUBLIC_MASTER_KEY_SIZE) != 0)) {
 		throw(REMOVE_ERROR, "Removing user failed.");
 	}
-	buffer_destroy_from_heap_and_null(list);
+	buffer_destroy_from_heap_and_null_if_valid(list);
 	printf("Successfully removed user.\n");
 
 	//clear the user store
@@ -271,17 +271,15 @@ cleanup:
 	if (store != NULL) {
 		user_store_destroy(store);
 	}
-	if (list != NULL) {
-		buffer_destroy_from_heap_and_null(list);
-	}
+	buffer_destroy_from_heap_and_null_if_valid(list);
 
-	buffer_destroy_from_heap_and_null(alice_public_signing_key);
-	buffer_destroy_from_heap_and_null(bob_public_signing_key);
-	buffer_destroy_from_heap_and_null(charlie_public_signing_key);
+	buffer_destroy_from_heap_and_null_if_valid(alice_public_signing_key);
+	buffer_destroy_from_heap_and_null_if_valid(bob_public_signing_key);
+	buffer_destroy_from_heap_and_null_if_valid(charlie_public_signing_key);
 
-	if (status.status != SUCCESS) {
+	on_error(
 		print_errors(&status);
-	}
+	)
 	return_status_destroy_errors(&status);
 
 	if (status_int != 0) {

--- a/test/utils.c
+++ b/test/utils.c
@@ -32,7 +32,7 @@ void print_hex(const buffer_t * const data) {
 
 	if (buffer_clone_as_hex(hex, data) != 0) {
 		fprintf(stderr, "ERROR: Failed printing hex.\n");
-		buffer_destroy_from_heap_and_null(hex);
+		buffer_destroy_from_heap_and_null_if_valid(hex);
 		return;
 	}
 
@@ -48,7 +48,7 @@ void print_hex(const buffer_t * const data) {
 	putchar('\n');
 
 	//cleanup
-	buffer_destroy_from_heap_and_null(hex);
+	buffer_destroy_from_heap_and_null_if_valid(hex);
 }
 
 void print_to_file(const buffer_t * const data, const char * const filename) {

--- a/test/zeroed_malloc-test.c
+++ b/test/zeroed_malloc-test.c
@@ -57,7 +57,7 @@ int main(void) {
 cleanup:
 	on_error(
 		print_errors(&status);
-	);
+	)
 	return_status_destroy_errors(&status);
 
 	return status.status;


### PR DESCRIPTION
It is to hard to split these commits, so both in one:
* replace all _and_null macros with _and_null_if_valid that check if a pointer is NULL before freeing anything
  * This has probably fixed a lot of bugs that could occur when an allocation failure happens and it has reduced the code size and visual complexity
* replace `if (status.status == SUCCESS)` with `on_error`
* use only ")" and not ");" for multiline macros